### PR TITLE
fix(promotion-detail.css)fix attendance display with scroll

### DIFF
--- a/css/promotion-detail.css
+++ b/css/promotion-detail.css
@@ -493,19 +493,41 @@ body {
 .attendance-table-wrapper {
     max-height: 700px;
     /* Allow dropdown to overflow without being clipped */
-    overflow: visible;
+    overflow-y: visible;
+    overflow-x: auto;
     position: relative;
+    display: block;
 }
 
 /* Create scroll context only for the table itself */
 .attendance-table-wrapper > .table-responsive {
     max-height: 700px;
-    overflow: auto;
+    overflow: visible;
+}
+
+/* Customize scrollbar appearance */
+.attendance-table-wrapper::-webkit-scrollbar {
+    height: 8px;
+}
+
+.attendance-table-wrapper::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 4px;
+}
+
+.attendance-table-wrapper::-webkit-scrollbar-thumb {
+    background: #fead8d;
+    border-radius: 4px;
+}
+
+.attendance-table-wrapper::-webkit-scrollbar-thumb:hover {
+    background: #fead8d;
 }
 
 .attendance-cell {
     width: 40px;
     min-width: 40px;
+    max-width: 40px;
     height: 40px;
     text-align: center;
     vertical-align: middle;
@@ -514,6 +536,7 @@ body {
     font-size: 0.8rem;
     padding: 0 !important;
     position: relative;
+    white-space: nowrap;
 }
 
 .attendance-cell:hover {
@@ -571,8 +594,9 @@ body {
 .sticky-column {
     position: sticky;
     left: 0;
-    z-index: 5;
+    z-index: 10;
     border-right: 2px solid #dee2e6 !important;
+    background-color: var(--complementario-1-extra-light);
 }
 
 .student-name-cell {

--- a/css/style.css
+++ b/css/style.css
@@ -274,7 +274,28 @@ body {
 /* Attendance Table Styles */
 .attendance-table-wrapper {
     max-height: 700px;
-    overflow: auto;
+    overflow-x: auto;
+    overflow-y: visible;
+    display: block;
+}
+
+/* Customize scrollbar appearance */
+.attendance-table-wrapper::-webkit-scrollbar {
+    height: 8px;
+}
+
+.attendance-table-wrapper::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 4px;
+}
+
+.attendance-table-wrapper::-webkit-scrollbar-thumb {
+    background: #ff4700;
+    border-radius: 4px;
+}
+
+.attendance-table-wrapper::-webkit-scrollbar-thumb:hover {
+    background: #d63900;
 }
 
 #attendance-table th,
@@ -283,7 +304,9 @@ body {
     vertical-align: middle;
     padding: 10px;
     min-width: 45px;
+    max-width: 45px;
     font-size: 0.7rem;
+    white-space: nowrap;
 }
 
 #attendance-table td.sticky-column,
@@ -292,7 +315,7 @@ body {
     left: 0;
     text-align: left;
     background-color: #f8f9fa;
-    z-index: 5;
+    z-index: 10;
     border-right: 2px solid #dee2e6;
 }
 


### PR DESCRIPTION
He implementado el desplazamiento horizontal en la tabla de asistencia. El problema era que en pantallas más estrechas que la propia cuadrícula, el contenido se cortaba o deformaba el diseño.

Se han aplicado cambios en style.css y promotion-detail.css que no afectan a la funcionalidad 
Para verlo: Abrir la vista de asistencia -> Reducir el ancho del navegador->Verificar que aparece la barra de desplazamiento lateral ( es de color naranja) y que se puede navegar por todas las fechas sin que se rompa el layout.

Cierra la issue: Closes #15