### PR TITLE
fix(evaluación): añadir texto "Repo" al botón del repositorio en la c…

### DIFF
--- a/public/js/promotion-detail.js
+++ b/public/js/promotion-detail.js
@@ -13137,9 +13137,9 @@ function selectEvalTarget(targetId) {
         // El link del repo se esconde detrás de un icono (antes era un <div class="alert">
         // grande con la URL completa siempre visible) — se abre en pestaña nueva al clicar.
         const linkHtml = hasLink ? `
-            <a href="${escapeHtml(savedEval.submissionLink)}" target="_blank" class="btn btn-sm btn-outline-secondary py-0 px-1"
+            <a href="${escapeHtml(savedEval.submissionLink)}" target="_blank" class="btn btn-sm btn-outline-secondary py-0 px-2"
                 title="Ver repositorio entregado: ${escapeHtml(savedEval.submissionLink)}">
-                <i class="bi bi-git"></i>
+                <i class="bi bi-git me-1"></i>Repo
             </a>` : '';
 
         headerEl.innerHTML = `


### PR DESCRIPTION
…abecera del grupo

El botón del repo entregado en #eval-right-header (split-view de evaluación) mostraba solo el icono de git → quedaba diminuto y poco claro. Ahora muestra el icono + "Repo" (con me-1 de separación y px-2 para que respire). Los otros dos enlaces de repositorio (vistas de histórico/grupal) ya llevaban texto.