### PR TITLE
fix: modal 'Modificar promoción' se abría con los campos vacíos

### DIFF
--- a/public/js/promotion-detail.js
+++ b/public/js/promotion-detail.js
@@ -7959,29 +7959,35 @@ function openEditPromotionModal() {
         return;
     }
 
-    // Pre-fill fields
-    const nameEl   = document.getElementById('edit-promotion-name');
-    const descEl   = document.getElementById('edit-promotion-desc');
-    const weeksEl  = document.getElementById('edit-promotion-weeks');
-    const hoursEl  = document.getElementById('edit-promotion-hours');
-    const startEl  = document.getElementById('edit-promotion-start');
-    const endEl    = document.getElementById('edit-promotion-end');
-    const alertEl  = document.getElementById('edit-promotion-alert');
-
-    if (nameEl)  nameEl.value  = promotion.name        || '';
-    if (descEl)  descEl.value  = promotion.description || '';
-    if (weeksEl) weeksEl.value = promotion.weeks       || '';
-    // Pre-fill totalHours from extendedInfoData if available
-    if (hoursEl) hoursEl.value = extendedInfoData?.totalHours || '';
-
-    // Dates arrive as ISO strings — convert to YYYY-MM-DD for <input type="date">
-    if (startEl) startEl.value = promotion.startDate ? promotion.startDate.slice(0, 10) : '';
-    if (endEl)   endEl.value   = promotion.endDate   ? promotion.endDate.slice(0, 10)   : '';
-
-    if (alertEl) alertEl.classList.add('d-none');
-
-    // editPromotionModal: ahora es shadcn Dialog (spec 0013-b).
+    // shadcn Dialog (spec 0013-e): abrir primero, poblar cuando Radix monte.
+    // Antes se leía document.getElementById(...) en el mismo tick que
+    // _openShadcnModal, pero Radix aún no había montado el contenido del
+    // Dialog (_openShadcnModal solo dispara un setState) — los getElementById
+    // devolvían null, el pre-fill se saltaba en silencio (guardas `if (el)`)
+    // y el modal se abría con los campos vacíos aunque currentPromotion sí
+    // tuviera los datos.
     window._openShadcnModal?.('editPromotionModal');
+    _whenMounted('edit-promotion-name', () => {
+        const nameEl   = document.getElementById('edit-promotion-name');
+        const descEl   = document.getElementById('edit-promotion-desc');
+        const weeksEl  = document.getElementById('edit-promotion-weeks');
+        const hoursEl  = document.getElementById('edit-promotion-hours');
+        const startEl  = document.getElementById('edit-promotion-start');
+        const endEl    = document.getElementById('edit-promotion-end');
+        const alertEl  = document.getElementById('edit-promotion-alert');
+
+        if (nameEl)  nameEl.value  = promotion.name        || '';
+        if (descEl)  descEl.value  = promotion.description || '';
+        if (weeksEl) weeksEl.value = promotion.weeks       || '';
+        // Pre-fill totalHours from extendedInfoData if available
+        if (hoursEl) hoursEl.value = extendedInfoData?.totalHours || '';
+
+        // Dates arrive as ISO strings — convert to YYYY-MM-DD for <input type="date">
+        if (startEl) startEl.value = promotion.startDate ? promotion.startDate.slice(0, 10) : '';
+        if (endEl)   endEl.value   = promotion.endDate   ? promotion.endDate.slice(0, 10)   : '';
+
+        if (alertEl) alertEl.classList.add('d-none');
+    });
 }
 
 async function saveEditPromotion(event) {


### PR DESCRIPTION
## Problema
Al abrir "Modificar promoción" desde el sidebar de `/promotion`, el modal aparecía con todos los campos vacíos (nombre, descripción, semanas, horas, fechas), aunque la promoción sí tenía esos datos guardados.

## Causa
Al migrar el modal a shadcn Dialog (spec 0013-b), `openEditPromotionModal()` en `public/js/promotion-detail.js` seguía leyendo `document.getElementById(...)` en el mismo tick en que se llama a `_openShadcnModal()`. Esa función solo dispara un `setState` de React, así que Radix aún no había montado el contenido del Dialog en ese momento: los `getElementById` devolvían `null`, el pre-fill se saltaba en silencio (por las guardas `if (el) ...`) y el modal terminaba abriéndose vacío, sin ningún error visible.

## Fix
Se aplica el mismo patrón que ya usan `openEditTeamModal` y `openResourceModal` (spec 0013-e): abrir el modal primero y usar el helper `_whenMounted()` (polling con `setTimeout`) para poblar los campos una vez que Radix haya montado el nodo en el DOM.

## Verificación
- Reproducido y parcheado en vivo contra producción: tras el fix, el modal muestra correctamente nombre, semanas, horas totales y fechas de inicio/fin.
- `node -c` sobre el archivo editado confirma sintaxis válida.
- Probado también levantando frontend (`next dev`) y backend (`node server.js`) en local, sin errores de consola relacionados con el cambio.