### PR TITLE
feat: varios proyectos activos a la vez en el Aula Virtual

### DIFF
--- a/app/promotion/_components/VirtualClassroomPanel.tsx
+++ b/app/promotion/_components/VirtualClassroomPanel.tsx
@@ -1,33 +1,30 @@
 'use client';
 
 /**
- * VirtualClassroomPanel.tsx — sub-tab "Aula Virtual" de Contenido del Programa (spec 0014 Fase C).
+ * VirtualClassroomPanel.tsx — sub-tab "Aula Virtual" de Contenido del Programa (spec 0014 Fase C,
+ * multi-proyecto spec 0015).
  *
  * 9º bloque extraído del orquestador. Reemplaza el panel #virtual-classroom-panel (form de
  * activación del Aula Virtual) que vivía en body.ts por un componente React montado por portal en
  * #program-details-virtual-classroom.
  *
- * Patrón "markup en React, lógica legacy por id" (igual que ScheduleSettings): el panel es un form
- * stateful muy acoplado a window._evalState (proyectos + competencias, que carga loadEvaluation).
- * En vez de replicar ~250 líneas de initVirtualClassroomPanel/updateVirtualClassroomCompetencesPreview/
- * onVirtualClassroomProjectChange/saveVirtualClassroom, React solo renderiza el MARKUP conservando
- * TODOS los ids legacy (vc-*), y el orquestador sigue poblándolos/leyéndolos por id:
+ * Patrón "markup en React, lógica legacy por id" (igual que ScheduleSettings): React SOLO renderiza
+ * el shell (cabecera + badge de estado global + contenedor vacío #vc-projects-list); todo el
+ * contenido variable (una fila por proyecto, cada una con su propio estado activo/inactivo) lo
+ * inyecta el orquestador vía innerHTML — igual que #groups-modal-body o #epcp-list.
  *  - initVirtualClassroomPanel(ext, promo) (lo llama switchProgramDetailsTab al abrir la pestaña y
- *    loadEvaluation) puebla el <select>, inputs, badge de estado y la preview de competencias. Es
- *    null-safe (early-return si los nodos no existen), así que el timing de montaje del portal no
- *    rompe nada: cuando el usuario abre la pestaña, el panel ya está montado.
- *  - El <select> dispara window.onVirtualClassroomProjectChange(); los botones llaman a
- *    window.saveVirtualClassroom(true) / window.deactivateVirtualClassroom().
- *  - #vc-project-select y #vc-competences-list los puebla el legacy vía innerHTML → se renderizan
- *    con contenido mínimo y NO se re-renderizan (el componente no tiene estado), evitando que React
- *    pise lo que inyecta el orquestador.
+ *    loadEvaluation) construye window._evalState.virtualClassrooms y llama a
+ *    _renderVirtualClassroomList(), que puebla #vc-projects-list con una fila por proyecto definido
+ *    en Evaluación (projectCompetences). Es null-safe (early-return si los nodos no existen), así
+ *    que el timing de montaje del portal no rompe nada.
+ *  - Cada fila trae sus propios botones, que llaman a window._vcToggleProject(this, true|false) —
+ *    activa/actualiza o desactiva SOLO ese proyecto, sin afectar a los demás que estén activos.
+ *  - #vc-projects-list lo puebla el legacy vía innerHTML → se renderiza vacío y NO se re-renderiza
+ *    (el componente no tiene estado), evitando que React pise lo que inyecta el orquestador.
  */
 
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function w(): any { return (typeof window !== 'undefined' ? window : {}) as unknown as any; }
 
 function usePortalNode(id: string): HTMLElement | null {
   const [node, setNode] = useState<HTMLElement | null>(null);
@@ -60,69 +57,18 @@ function VirtualClassroomPanel() {
           <div>
             <h5 className="mb-1"><i className="bi bi-laptop me-2 text-primary" />Aula Virtual</h5>
             <p className="text-muted small mb-0">
-              Activa un proyecto para que el estudiantado entregue su repositorio desde la vista pública.
+              Activa uno o varios proyectos a la vez (por ejemplo, uno por especialización) para que
+              el estudiantado entregue su repositorio desde la vista pública.
             </p>
           </div>
           <div className="text-end">
-            <span className="badge bg-secondary" id="vc-status-badge">Sin proyecto activo</span>
+            <span className="badge bg-secondary" id="vc-status-badge">Sin proyectos activos</span>
           </div>
         </div>
 
-        <div className="row g-3 align-items-end">
-          <div className="col-md-5">
-            <label htmlFor="vc-project-select" className="form-label small fw-semibold text-muted">Proyecto vinculado</label>
-            <select id="vc-project-select" className="form-select form-select-sm" onChange={() => w().onVirtualClassroomProjectChange?.()}>
-              <option value="">Selecciona módulo y proyecto…</option>
-            </select>
-            <div className="form-text small" id="vc-project-help">Los proyectos se configuran en la sección Evaluación.</div>
-          </div>
-          <div className="col-md-3">
-            <label htmlFor="vc-repo-base" className="form-label small fw-semibold text-muted">
-              URL base del repositorio
-              <span id="vc-repo-base-source" className="badge bg-success text-white ms-1 small d-none"><i className="bi bi-github me-1" />desde GitHub</span>
-            </label>
-            <input type="text" id="vc-repo-base" className="form-control form-control-sm" placeholder="https://github.com/proyectof5/" />
-            <div id="vc-repo-base-hint" className="form-text small text-muted d-none">URL tomada del quick link de GitHub. Puedes editarla manualmente.</div>
-          </div>
-          <div className="col-md-4">
-            <label htmlFor="vc-briefing-url" className="form-label small fw-semibold text-muted">
-              Link al briefing del proyecto
-              <span id="vc-briefing-source" className="badge bg-info text-dark ms-1 small d-none"><i className="bi bi-link-45deg me-1" />desde roadmap</span>
-            </label>
-            <input type="text" id="vc-briefing-url" className="form-control form-control-sm" placeholder="https://github.com/organizacion/briefing-proyecto" />
-            <div id="vc-briefing-hint" className="form-text small text-muted d-none">URL definida en el roadmap. Puedes editarla manualmente si lo necesitas.</div>
-          </div>
-        </div>
-
-        <div className="row g-3 align-items-end mt-1">
-          <div className="col-md-3">
-            <label htmlFor="vc-due-date" className="form-label small fw-semibold text-muted">
-              <i className="bi bi-calendar-event me-1" />Fecha de entrega <span className="text-muted fw-normal">(opcional)</span>
-            </label>
-            <input type="date" id="vc-due-date" className="form-control form-control-sm" />
-            <div className="form-text small text-muted">Se mostrará de forma destacada en el Aula Virtual pública.</div>
-          </div>
-        </div>
-
-        <div className="row g-3 mt-3">
-          <div className="col-md-8">
-            <div className="border rounded p-2 bg-light">
-              <div className="d-flex justify-content-between align-items-center mb-1">
-                <span className="small fw-semibold text-muted">Competencias a evaluar (definidas en Evaluación)</span>
-                <span className="badge bg-light text-dark border small" id="vc-competences-count">0 competencias</span>
-              </div>
-              <div id="vc-competences-list" className="small text-muted">
-                <span className="fst-italic">Selecciona un proyecto para ver sus competencias.</span>
-              </div>
-            </div>
-          </div>
-          <div className="col-md-4 d-flex justify-content-md-end align-items-start gap-2 mt-2 mt-md-0">
-            <button type="button" className="btn btn-sm btn-outline-secondary" id="vc-deactivate-btn" onClick={() => w().deactivateVirtualClassroom?.()} disabled>
-              <i className="bi bi-x-circle me-1" />Desactivar
-            </button>
-            <button type="button" className="btn btn-sm btn-primary" id="vc-activate-btn" onClick={() => w().saveVirtualClassroom?.(true)}>
-              <i className="bi bi-play-circle me-1" />Activar Aula Virtual
-            </button>
+        <div id="vc-projects-list">
+          <div className="text-center text-muted small py-3">
+            <div className="spinner-border spinner-border-sm me-2" role="status" />Cargando proyectos…
           </div>
         </div>
       </div>

--- a/app/public-promotion/_components/AulaVirtual.tsx
+++ b/app/public-promotion/_components/AulaVirtual.tsx
@@ -9,7 +9,7 @@ import {
   AccordionContent,
 } from '@/components/ui/accordion';
 import { getApiUrl } from '@/lib/api';
-import type { PPVirtualClassroom, PPVCCompetence, PPStudent, PPSubmission, PPLevel } from './types';
+import type { PPVCProject, PPVCCompetence, PPStudent, PPSubmission, PPLevel } from './types';
 import { indName } from './types';
 
 const API_URL = getApiUrl();
@@ -86,18 +86,79 @@ function CompetenceCard({ comp }: { comp: PPVCCompetence }) {
   );
 }
 
+// Punto de entrada público: recibe TODOS los proyectos activos (puede haber varios a la vez, uno
+// por especialización/briefing). Si hay más de uno, primero pide elegir a cuál se va a entregar —
+// esta página no tiene login, así que no hay forma de adivinarlo automáticamente.
 export function AulaVirtual({
-  vc,
+  projects,
   students,
   promotionId,
   onClose,
 }: {
-  vc: PPVirtualClassroom;
+  projects: PPVCProject[];
   students: PPStudent[];
   promotionId: string;
   onClose: () => void;
 }) {
+  const [selectedIdx, setSelectedIdx] = useState<number | null>(projects.length === 1 ? 0 : null);
+
+  if (selectedIdx === null) {
+    return (
+      <div className="bg-white rounded-lg shadow border border-border">
+        <div className="p-4">
+          <div className="flex justify-between items-center flex-wrap gap-2 mb-3">
+            <h5 className="m-0 flex items-center gap-2 text-lg font-semibold"><Laptop className="h-5 w-5" />Aula Virtual</h5>
+            <button className="btn btn-sm btn-outline-secondary inline-flex items-center gap-1" onClick={onClose}>
+              <ArrowLeft className="h-3 w-3" />Volver al inicio
+            </button>
+          </div>
+          <p className="text-sm text-muted-foreground mb-3">Hay varios proyectos activos. Elige a cuál vas a entregar:</p>
+          <div className="flex flex-col gap-2">
+            {projects.map((p, i) => (
+              <button
+                key={i}
+                type="button"
+                className="border border-border rounded px-3 py-3 text-left hover:bg-gray-50 flex justify-between items-center gap-2"
+                onClick={() => setSelectedIdx(i)}
+              >
+                <span className="font-semibold">{p.project?.projectName || `Proyecto ${i + 1}`}</span>
+                {p.project?.moduleName && <span className="text-xs text-muted-foreground">{p.project.moduleName}</span>}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <AulaVirtualProject
+      vc={projects[selectedIdx]}
+      students={students}
+      promotionId={promotionId}
+      onClose={onClose}
+      onChangeProject={projects.length > 1 ? () => setSelectedIdx(null) : undefined}
+    />
+  );
+}
+
+// Vista de un único proyecto ya elegido: briefing, competencias, entregas y el formulario de envío.
+function AulaVirtualProject({
+  vc,
+  students,
+  promotionId,
+  onClose,
+  onChangeProject,
+}: {
+  vc: PPVCProject;
+  students: PPStudent[];
+  promotionId: string;
+  onClose: () => void;
+  onChangeProject?: () => void;
+}) {
   const type = vc.projectType === 'grupal' ? 'grupal' : 'individual';
+  const moduleId = vc.project?.moduleId || '';
+  const projectName = vc.project?.projectName || '';
   const repoPrefix = vc.repoBaseUrl && vc.repoBaseUrl.trim()
     ? vc.repoBaseUrl.trim().replace(/\/+$/, '') + '/'
     : 'https://github.com/';
@@ -110,14 +171,15 @@ export function AulaVirtual({
 
   const refreshSubmissions = useCallback(async () => {
     try {
-      const res = await fetch(`${API_URL}/api/promotions/${promotionId}/virtual-classroom/submissions?type=${type}`);
+      const qs = new URLSearchParams({ type, moduleId, projectName });
+      const res = await fetch(`${API_URL}/api/promotions/${promotionId}/virtual-classroom/submissions?${qs}`);
       if (!res.ok) return;
       const data = await res.json();
       setSubmissions(data.submissions || []);
     } catch {
       /* noop */
     }
-  }, [promotionId, type]);
+  }, [promotionId, type, moduleId, projectName]);
 
   useEffect(() => { refreshSubmissions(); }, [refreshSubmissions]);
 
@@ -137,7 +199,7 @@ export function AulaVirtual({
     if (!target) { setFeedback({ text: 'Selecciona tu nombre o equipo antes de enviar.', ok: false }); return; }
     if (!repoSuffix.trim()) { setFeedback({ text: 'Escribe el nombre de tu repositorio.', ok: false }); return; }
     const [, id] = target.split(':');
-    const body: Record<string, string> = { type, repoName: repoSuffix.trim() };
+    const body: Record<string, string> = { type, repoName: repoSuffix.trim(), moduleId, projectName };
     if (type === 'grupal') body.groupName = id; else body.studentId = id;
     setSubmitting(true);
     setFeedback(null);
@@ -167,9 +229,14 @@ export function AulaVirtual({
       <div className="p-4">
         <div className="flex justify-between items-center flex-wrap gap-2 mb-3">
           <h5 className="m-0 flex items-center gap-2 text-lg font-semibold"><Laptop className="h-5 w-5" />Aula Virtual</h5>
-          <button className="btn btn-sm btn-outline-secondary inline-flex items-center gap-1" onClick={onClose}>
-            <ArrowLeft className="h-3 w-3" />Volver al inicio
-          </button>
+          <div className="flex items-center gap-2">
+            {onChangeProject && (
+              <button className="btn btn-sm btn-outline-secondary" onClick={onChangeProject}>Cambiar de proyecto</button>
+            )}
+            <button className="btn btn-sm btn-outline-secondary inline-flex items-center gap-1" onClick={onClose}>
+              <ArrowLeft className="h-3 w-3" />Volver al inicio
+            </button>
+          </div>
         </div>
 
         {vc.project?.projectName && <p className="mb-3 font-semibold text-lg text-center">{vc.project.projectName}</p>}

--- a/app/public-promotion/_components/types.ts
+++ b/app/public-promotion/_components/types.ts
@@ -162,15 +162,20 @@ export interface PPVCGroup {
   groupName: string;
   studentIds?: string[];
 }
-export interface PPVirtualClassroom {
-  active: boolean;
+// Un proyecto activo del Aula Virtual (puede haber varios a la vez — uno por especialización).
+export interface PPVCProject {
   projectType?: string;
-  project?: { projectName?: string };
+  project?: { moduleId?: string; moduleName?: string; projectName?: string };
   briefingUrl?: string;
   dueDate?: string;
   competences?: PPVCCompetence[];
   repoBaseUrl?: string;
   groups?: PPVCGroup[];
+}
+// Respuesta de GET /virtual-classroom: 0, 1 o varios proyectos activos simultáneamente.
+export interface PPVirtualClassroomResponse {
+  active: boolean;
+  projects: PPVCProject[];
 }
 export interface PPSubmission {
   targetId: string;

--- a/app/public-promotion/page.tsx
+++ b/app/public-promotion/page.tsx
@@ -46,7 +46,8 @@ import type {
   PPSection,
   PPPromoResource,
   PPExtendedInfo,
-  PPVirtualClassroom,
+  PPVCProject,
+  PPVirtualClassroomResponse,
 } from './_components/types';
 
 import './public-promotion.css';
@@ -87,7 +88,7 @@ export default function PublicPromotionPage() {
   const [sections, setSections] = useState<PPSection[]>([]);
   const [promoResources, setPromoResources] = useState<PPPromoResource[]>([]);
   const [extended, setExtended] = useState<PPExtendedInfo | null>(null);
-  const [vc, setVc] = useState<PPVirtualClassroom | null>(null);
+  const [vcProjects, setVcProjects] = useState<PPVCProject[]>([]);
   const [aulaOpen, setAulaOpen] = useState(false);
 
   const [activeTab, setActiveTab] = useState<'progreso' | 'info'>('progreso');
@@ -114,8 +115,8 @@ export default function PublicPromotionPage() {
       get<PPPromoResource[]>('/promotion-resources', []),
       get<PPExtendedInfo | null>(`/extended-info?t=${Date.now()}`, null),
     ]);
-    const vcData = await get<PPVirtualClassroom | null>('/virtual-classroom', null);
-    setVc(vcData && vcData.active ? vcData : null);
+    const vcData = await get<PPVirtualClassroomResponse>('/virtual-classroom', { active: false, projects: [] });
+    setVcProjects(vcData && vcData.active ? (vcData.projects || []) : []);
     if (promo) {
       setPromotion(promo);
       document.title = `${promo.name} - Bootcamp`;
@@ -294,14 +295,16 @@ export default function PublicPromotionPage() {
     return <div className="alert alert-danger m-5">Promotion not found</div>;
   }
 
-  // Aula Virtual ocupa toda la vista (como "página") cuando se abre
-  if (aulaOpen && vc && promotionId) {
+  // Aula Virtual ocupa toda la vista (como "página") cuando se abre. AulaVirtual recibe TODOS los
+  // proyectos activos (puede haber varios — uno por especialización) y muestra un selector si hay
+  // más de uno antes de dejar entregar.
+  if (aulaOpen && vcProjects.length > 0 && promotionId) {
     return (
       <div style={{ flex: '1 1 100%', width: '100%', minHeight: '100vh' }}>
         <div className="container">
           <div className="row">
             <main className="col-12 py-4">
-              <AulaVirtual vc={vc} students={students} promotionId={promotionId} onClose={() => setAulaOpen(false)} />
+              <AulaVirtual projects={vcProjects} students={students} promotionId={promotionId} onClose={() => setAulaOpen(false)} />
             </main>
           </div>
         </div>
@@ -429,10 +432,11 @@ export default function PublicPromotionPage() {
             )}
 
             {/* ── CTA Aula Virtual ── */}
-            {vc && (
+            {vcProjects.length > 0 && (
               <div className="mb-4">
                 <button type="button" className="pp-cta-btn inline-flex items-center gap-2" onClick={() => setAulaOpen(true)}>
                   <Laptop className="h-4 w-4" />Ir al Aula Virtual
+                  {vcProjects.length > 1 && <span className="badge bg-light text-dark border ms-1">{vcProjects.length} proyectos</span>}
                 </button>
               </div>
             )}

--- a/public/js/promotion-detail.js
+++ b/public/js/promotion-detail.js
@@ -2098,33 +2098,11 @@ async function saveExtendedInfo() {
     extendedInfoData.pildoras = allPildoras;
     
     // ── Sync Virtual Classroom state ──────────────────────────────────────────
-    // Ensure we don't overwrite the virtualClassroom with stale data if it was updated in its own tab
-    const vcSelectEl = document.getElementById('vc-project-select');
-    const vcStatusBadge = document.getElementById('vc-status-badge');
-    if (vcSelectEl && vcStatusBadge) {
-        const val = vcSelectEl.value;
-        const [vMid, vPname] = val ? val.split('__') : ['', ''];
-        const vRepo = document.getElementById('vc-repo-base')?.value || '';
-        const vBrief = document.getElementById('vc-briefing-url')?.value || '';
-        const vActive = vcStatusBadge.classList.contains('bg-success');
-        
-        // Find project type for the selected project
-        const savedEvaluations = window._evalState?.savedEvaluations || [];
-        // FIXED: Search by projectName ONLY to match backend storage of Aula Virtual submissions
-        const existingEval = savedEvaluations.find(e => e.projectName === vPname);
-        const vType = existingEval ? (existingEval.type || 'individual') : 'individual';
-
-        extendedInfoData.virtualClassroom = {
-            isActive: vActive,
-            moduleId: vMid,
-            projectName: vPname,
-            projectType: vType,
-            repoBaseUrl: vRepo,
-            briefingUrl: vBrief
-        };
-    } else if (window._evalState && window._evalState.virtualClassroom) {
-        // Fallback to memory state if DOM is not present 
-        extendedInfoData.virtualClassroom = window._evalState.virtualClassroom;
+    // Cada proyecto del Aula Virtual ya se guarda al vuelo al activar/desactivar/actualizar
+    // (_persistVirtualClassrooms), así que aquí solo evitamos que este guardado masivo mande una
+    // versión desactualizada si window._evalState.virtualClassrooms es la más fresca.
+    if (window._evalState && Array.isArray(window._evalState.virtualClassrooms)) {
+        extendedInfoData.virtualClassrooms = window._evalState.virtualClassrooms;
     }
 
     //console.log('Saving extended info for promotion:', promotionId);
@@ -11037,6 +11015,7 @@ window._evalState = {
     savedEvaluations: [],
     projectCompetences: [],
     virtualClassroom: null,
+    virtualClassrooms: [],
     currentModuleIdx: null,
     currentProjectIdx: null
 };
@@ -11200,23 +11179,16 @@ function _initEvalFeedbackRteKeyHandler() {
 
 // ==================== AULA VIRTUAL – PANEL PROFESOR ====================
 
+// ==================== AULA VIRTUAL — varios proyectos activos a la vez ====================
+// Cada proyecto definido en Evaluación (projectCompetences) tiene su propia fila con su propio
+// estado activo/inactivo, repoBaseUrl/briefingUrl/dueDate — ya no hay un único "proyecto vinculado"
+// global. window._evalState.virtualClassrooms es el array persistido (uno por moduleId+projectName).
+
 function initVirtualClassroomPanel(ext, promo) {
     const panel = document.getElementById('virtual-classroom-panel');
     if (!panel) return;
 
-    const selectEl = document.getElementById('vc-project-select');
-    const repoBaseEl = document.getElementById('vc-repo-base');
-    const briefingEl = document.getElementById('vc-briefing-url');
-    const statusBadge = document.getElementById('vc-status-badge');
-    const deactivateBtn = document.getElementById('vc-deactivate-btn');
-    const activateBtn = document.getElementById('vc-activate-btn');
-    const competencesList = document.getElementById('vc-competences-list');
-    const competencesCount = document.getElementById('vc-competences-count');
-
-    if (!selectEl || !repoBaseEl || !briefingEl || !statusBadge || !deactivateBtn || !activateBtn) return;
-
     const modules = promo.modules || [];
-    const projectCompetences = window._evalState.projectCompetences || [];
 
     // Build a quick lookup: "moduleId__projectName" → url (from roadmap)
     window._projectUrlMap = {};
@@ -11229,118 +11201,126 @@ function initVirtualClassroomPanel(ext, promo) {
         });
     });
 
-    // Map rápido de módulo por id para obtener el nombre de módulo
-    const moduleById = {};
-    modules.forEach((m, idx) => {
-        const id = m.id || String(idx);
-        moduleById[id] = m;
-    });
-
-    // Populate project selector SOLO con los proyectos definidos en Evaluación (projectCompetences)
-    const prevValue = selectEl.value;
-    let optionsHtml = '<option value="">Selecciona módulo y proyecto…</option>';
-
-    projectCompetences.forEach(pc => {
-        const modId = pc.moduleId;
-        const mod = moduleById[modId];
-        const labelModule = mod ? (mod.name || '') : `Módulo ${modId}`;
-        const value = `${modId}__${pc.projectName}`;
-        const label = `${labelModule} — ${pc.projectName}`;
-        optionsHtml += `<option value="${value}">${escapeHtml(label)}</option>`;
-    });
-
-    selectEl.innerHTML = optionsHtml;
-
-    // Pre-select active project if any
-    const vc = ext.virtualClassroom || {};
-    let activeValue = '';
-    if (vc && vc.moduleId && vc.projectName) {
-        activeValue = `${vc.moduleId}__${vc.projectName}`;
-    }
-    // Solo mantener el valor si existe en el selector actual
-    const candidate = activeValue || prevValue || '';
-    if (candidate && Array.from(selectEl.options).some(o => o.value === candidate)) {
-        selectEl.value = candidate;
+    // Migración: si aún no hay virtualClassrooms (array nuevo) pero sí un virtualClassroom
+    // (objeto único, legacy) activo, lo usamos como fila inicial. No se vuelve a escribir en el
+    // campo singular a partir de aquí — la próxima vez que se guarde, ya se persiste en el array.
+    if (Array.isArray(ext.virtualClassrooms) && ext.virtualClassrooms.length) {
+        window._evalState.virtualClassrooms = JSON.parse(JSON.stringify(ext.virtualClassrooms));
+    } else if (ext.virtualClassroom && ext.virtualClassroom.isActive && ext.virtualClassroom.moduleId) {
+        window._evalState.virtualClassrooms = [JSON.parse(JSON.stringify(ext.virtualClassroom))];
     } else {
-        selectEl.value = '';
+        window._evalState.virtualClassrooms = window._evalState.virtualClassrooms || [];
     }
 
-    // Fill inputs from active config
-    // Repo base: prefer saved value, fall back to GitHub quick link
-    const _githubUrl = window._githubQuickLinkUrl || '';
-    if (vc.repoBaseUrl) {
-        repoBaseEl.value = vc.repoBaseUrl;
-        _setRepoBaseBadge(false);
-    } else if (_githubUrl) {
-        repoBaseEl.value = _githubUrl;
-        _setRepoBaseBadge(true);
-    } else {
-        repoBaseEl.value = '';
-        _setRepoBaseBadge(false);
-    }
-    // Fill briefing URL — prefer roadmap URL for the selected project (auto-fill)
-    const _activeKey = selectEl.value;
-    const _roadmapUrl = _activeKey && window._projectUrlMap ? window._projectUrlMap[_activeKey] : '';
-    if (_roadmapUrl) {
-        briefingEl.value = _roadmapUrl;
-        _setBriefingSourceBadge(true);
-    } else {
-        briefingEl.value = vc.briefingUrl || '';
-        _setBriefingSourceBadge(false);
-    }
-
-    // Fill due date
-    const dueDateEl = document.getElementById('vc-due-date');
-    if (dueDateEl) dueDateEl.value = vc.dueDate || '';
-
-    // Update status UI
-    if (vc.isActive && activeValue) {
-        statusBadge.textContent = `Proyecto activo: ${vc.projectName}`;
-        statusBadge.className = 'badge bg-success';
-        deactivateBtn.disabled = false;
-        activateBtn.textContent = 'Actualizar Aula Virtual';
-        activateBtn.innerHTML = '<i class="bi bi-arrow-repeat me-1"></i>Actualizar Aula Virtual';
-    } else {
-        statusBadge.textContent = 'Sin proyecto activo';
-        statusBadge.className = 'badge bg-secondary';
-        deactivateBtn.disabled = true;
-        activateBtn.innerHTML = '<i class="bi bi-play-circle me-1"></i>Activar Aula Virtual';
-    }
-
-    // Render competences preview for selected/active project
-    updateVirtualClassroomCompetencesPreview();
+    _renderVirtualClassroomList();
 }
 
-function updateVirtualClassroomCompetencesPreview() {
-    const selectEl = document.getElementById('vc-project-select');
-    const competencesList = document.getElementById('vc-competences-list');
-    const competencesCount = document.getElementById('vc-competences-count');
-    if (!selectEl || !competencesList || !competencesCount) return;
+function _moduleNameById(modId) {
+    const modules = window._evalState.modules || [];
+    const mod = modules.find((m, idx) => (m.id || String(idx)) === modId);
+    return mod ? (mod.name || '') : `Módulo ${modId}`;
+}
 
-    const value = selectEl.value;
-    if (!value) {
-        competencesList.innerHTML = '<span class="fst-italic">Selecciona un proyecto para ver sus competencias.</span>';
-        competencesCount.textContent = '0 competencias';
+function _renderVirtualClassroomList() {
+    const listEl = document.getElementById('vc-projects-list');
+    const statusBadge = document.getElementById('vc-status-badge');
+    if (!listEl) return;
+
+    const projectCompetences = window._evalState.projectCompetences || [];
+    const vcList = window._evalState.virtualClassrooms || [];
+    const activeCount = vcList.filter(vc => vc && vc.isActive).length;
+
+    if (statusBadge) {
+        if (activeCount > 0) {
+            statusBadge.textContent = `${activeCount} proyecto${activeCount !== 1 ? 's' : ''} activo${activeCount !== 1 ? 's' : ''}`;
+            statusBadge.className = 'badge bg-success';
+        } else {
+            statusBadge.textContent = 'Sin proyectos activos';
+            statusBadge.className = 'badge bg-secondary';
+        }
+    }
+
+    if (!projectCompetences.length) {
+        listEl.innerHTML = `<div class="alert alert-info small mb-0">
+            <i class="bi bi-info-circle me-2"></i>
+            Todavía no hay proyectos con competencias definidas. Ve a la pestaña <strong>Evaluación</strong>
+            y usa <strong>Definir competencias</strong> en cada proyecto que quieras poder activar aquí.
+        </div>`;
         return;
     }
 
-    const [moduleId, projectName] = value.split('__');
-    const pcEntry = (window._evalState.projectCompetences || []).find(
-        pc => pc.moduleId === moduleId && pc.projectName === projectName
-    );
+    const _githubUrl = window._githubQuickLinkUrl || '';
 
-    const compIds = pcEntry ? (pcEntry.competenceIds || []) : [];
+    listEl.innerHTML = projectCompetences.map((pc, i) => {
+        const modId = pc.moduleId;
+        const projectName = pc.projectName;
+        const key = `${modId}__${projectName}`;
+        const vc = vcList.find(v => v && String(v.moduleId) === String(modId) && v.projectName === projectName) || {};
+        const isActive = !!vc.isActive;
+
+        const roadmapUrl = window._projectUrlMap[key] || '';
+        const briefingUrl = vc.briefingUrl || roadmapUrl || '';
+        const briefingFromRoadmap = !vc.briefingUrl && !!roadmapUrl;
+        const repoBaseUrl = vc.repoBaseUrl || _githubUrl || '';
+        const repoFromGithub = !vc.repoBaseUrl && !!_githubUrl;
+
+        const compIds = pc.competenceIds || [];
+        const compAccordionId = `vc-comp-${i}`;
+
+        return `
+        <div class="border rounded p-3 mb-3 vc-project-card" data-mod-id="${escapeHtml(String(modId))}" data-project-name="${escapeHtml(projectName)}">
+            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-2">
+                <div>
+                    <span class="fw-semibold">${escapeHtml(_moduleNameById(modId))} — ${escapeHtml(projectName)}</span>
+                    <span class="badge ${isActive ? 'bg-success' : 'bg-secondary'} ms-2">${isActive ? 'Activo' : 'Inactivo'}</span>
+                </div>
+            </div>
+            <div class="row g-3 align-items-end">
+                <div class="col-md-4">
+                    <label class="form-label small fw-semibold text-muted">
+                        URL base del repositorio
+                        ${repoFromGithub ? '<span class="badge bg-success text-white ms-1 small"><i class="bi bi-github me-1"></i>desde GitHub</span>' : ''}
+                    </label>
+                    <input type="text" class="form-control form-control-sm vc-repo-base-input" value="${escapeHtml(repoBaseUrl)}" placeholder="https://github.com/proyectof5/">
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label small fw-semibold text-muted">
+                        Link al briefing
+                        ${briefingFromRoadmap ? '<span class="badge bg-info text-dark ms-1 small"><i class="bi bi-link-45deg me-1"></i>desde roadmap</span>' : ''}
+                    </label>
+                    <input type="text" class="form-control form-control-sm vc-briefing-input" value="${escapeHtml(briefingUrl)}" placeholder="https://...">
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label small fw-semibold text-muted"><i class="bi bi-calendar-event me-1"></i>Fecha de entrega</label>
+                    <input type="date" class="form-control form-control-sm vc-due-date-input" value="${vc.dueDate || ''}">
+                </div>
+                <div class="col-md-2 d-flex gap-2 justify-content-end">
+                    <button type="button" class="btn btn-sm btn-outline-secondary" ${!isActive ? 'disabled' : ''} onclick="window._vcToggleProject(this, false)" title="Desactivar">
+                        <i class="bi bi-x-circle"></i>
+                    </button>
+                    <button type="button" class="btn btn-sm btn-primary" onclick="window._vcToggleProject(this, true)">
+                        <i class="bi bi-${isActive ? 'arrow-repeat' : 'play-circle'} me-1"></i>${isActive ? 'Actualizar' : 'Activar'}
+                    </button>
+                </div>
+            </div>
+            <div class="mt-2">
+                <button class="btn btn-link btn-sm p-0" type="button" data-bs-toggle="collapse" data-bs-target="#${compAccordionId}">
+                    <i class="bi bi-award me-1"></i>${compIds.length} competencia${compIds.length !== 1 ? 's' : ''} — ver detalle
+                </button>
+                <div class="collapse" id="${compAccordionId}">
+                    <div class="mt-2">${compIds.length ? _buildVcCompetencesAccordionHtml(pc, i) : '<span class="fst-italic small text-muted">Este proyecto no tiene competencias definidas todavía en Evaluación.</span>'}</div>
+                </div>
+            </div>
+        </div>`;
+    }).join('');
+}
+
+function _buildVcCompetencesAccordionHtml(pcEntry, rowIdx) {
+    const compIds = pcEntry.competenceIds || [];
     const catalog = window._evalState.catalog || window._evalState.competences || [];
+    const pcTools = pcEntry.competenceTools || {};
 
-    if (!compIds.length) {
-        competencesList.innerHTML = '<span class="fst-italic">Este proyecto no tiene competencias definidas todavía en Evaluación.</span>';
-        competencesCount.textContent = '0 competencias';
-        return;
-    }
-
-    const pcTools = (pcEntry && pcEntry.competenceTools) ? pcEntry.competenceTools : {};
-    
-    const mainAccordionId = `vc-preview-acc`;
+    const mainAccordionId = `vc-preview-acc-${rowIdx}`;
     const items = compIds.map((cid, idx) => {
         const cidStr = String(cid);
         const c = catalog.find(ec => String(ec.id) === cidStr);
@@ -11351,7 +11331,7 @@ function updateVirtualClassroomCompetencesPreview() {
         const selectedToolNames = pcTools[cidStr] || [];
         const allToolObjs = c.toolsWithIndicators || [];
         const tools = allToolObjs.filter(t => selectedToolNames.includes(t.name));
-        
+
         const LEVEL_COLORS = { 1: '#ffc107', 2: '#0d6efd', 3: '#198754' };
         const LEVEL_BG = { 1: '#fff3cd', 2: '#cfe2ff', 3: '#d1e7dd' };
         const LEVEL_NAMES = { 1: 'Básico', 2: 'Medio', 3: 'Avanzado' };
@@ -11360,8 +11340,8 @@ function updateVirtualClassroomCompetencesPreview() {
         const compLevelCols = [1, 2, 3].map(lvl => {
             const catInds = lvl === 1 ? compInds.initial : (lvl === 2 ? compInds.medio : compInds.advance);
             const levelObj = (c.levels || []).find(l => l.level === lvl);
-            const finalIndNames = (catInds && catInds.length > 0) 
-                ? catInds.map(i => i.name || i) 
+            const finalIndNames = (catInds && catInds.length > 0)
+                ? catInds.map(i => i.name || i)
                 : (levelObj && levelObj.indicators ? levelObj.indicators : []);
 
             const desc = levelDescs[lvl] || LEVEL_NAMES[lvl];
@@ -11382,7 +11362,7 @@ function updateVirtualClassroomCompetencesPreview() {
         }).join('');
 
         // Tool accordion
-        const toolAccordionId = `vc-tool-acc-${idx}`;
+        const toolAccordionId = `vc-tool-acc-${rowIdx}-${idx}`;
         const toolAccordionHtml = tools.length > 0 ? `
             <div class="accordion accordion-flush mt-3 border rounded shadow-sm" id="${toolAccordionId}">
                 <div class="bg-light px-3 py-2 border-bottom extra-small fw-bold text-uppercase text-muted" style="font-size: 0.6rem; letter-spacing: 0.05em;">
@@ -11391,7 +11371,7 @@ function updateVirtualClassroomCompetencesPreview() {
                 ${tools.map((tool, tIdx) => {
                     const toolByLevel = { 1: [], 2: [], 3: [] };
                     (tool.indicators || []).forEach(ind => { if (toolByLevel[ind.levelId]) toolByLevel[ind.levelId].push(ind); });
-                    
+
                     const toolLevelCols = [1, 2, 3].filter(l => toolByLevel[l].length > 0).map(lvl => `
                         <div class="col-md-4">
                             <div class="extra-small fw-bold mb-1 text-uppercase" style="color:${LEVEL_COLORS[lvl]}; font-size: 0.55rem;">
@@ -11406,7 +11386,7 @@ function updateVirtualClassroomCompetencesPreview() {
                     return `
                         <div class="accordion-item">
                             <h2 class="accordion-header">
-                                <button class="accordion-button collapsed py-2 px-3 small fw-bold" type="button" 
+                                <button class="accordion-button collapsed py-2 px-3 small fw-bold" type="button"
                                     data-bs-toggle="collapse" data-bs-target="#${toolAccordionId}-${tIdx}">
                                     ${escapeHtml(tool.name)}
                                 </button>
@@ -11423,11 +11403,11 @@ function updateVirtualClassroomCompetencesPreview() {
             </div>
         ` : '';
 
-        const collapseId = `vc-prev-collapse-${idx}`;
+        const collapseId = `vc-prev-collapse-${rowIdx}-${idx}`;
         return `
             <div class="accordion-item shadow-sm mb-2 border rounded overflow-hidden">
                 <h2 class="accordion-header">
-                    <button class="accordion-button ${idx === 0 ? '' : 'collapsed'} py-2 px-3" type="button" 
+                    <button class="accordion-button ${idx === 0 ? '' : 'collapsed'} py-2 px-3" type="button"
                         data-bs-toggle="collapse" data-bs-target="#${collapseId}">
                         <div class="d-flex align-items-center gap-2">
                             <span class="badge bg-primary px-2" style="font-size: 0.65rem;">${escapeHtml(c.area || 'General')}</span>
@@ -11448,66 +11428,19 @@ function updateVirtualClassroomCompetencesPreview() {
         `;
     }).join('');
 
-    competencesList.innerHTML = `<div class="accordion accordion-flush" id="${mainAccordionId}">${items}</div>`;
-    competencesCount.textContent = `${compIds.length} competencia${compIds.length !== 1 ? 's' : ''}`;
+    return `<div class="accordion accordion-flush" id="${mainAccordionId}">${items}</div>`;
 }
 
-// Called by select change in the panel
-window.onVirtualClassroomProjectChange = function () {
-    updateVirtualClassroomCompetencesPreview();
-    const selectEl = document.getElementById('vc-project-select');
-    if (selectEl) _applyBriefingUrlFromRoadmap(selectEl.value);
-};
+// Activa/actualiza o desactiva UN proyecto concreto (no afecta a los demás activos).
+window._vcToggleProject = async function (btnEl, isActive) {
+    const card = btnEl.closest('.vc-project-card');
+    if (!card) return;
+    const modId = card.dataset.modId;
+    const projectName = card.dataset.projectName;
 
-function _setBriefingSourceBadge(fromRoadmap) {
-    const badge = document.getElementById('vc-briefing-source');
-    const hint = document.getElementById('vc-briefing-hint');
-    if (badge) badge.classList.toggle('d-none', !fromRoadmap);
-    if (hint) hint.classList.toggle('d-none', !fromRoadmap);
-}
-
-function _setRepoBaseBadge(fromGithub) {
-    const badge = document.getElementById('vc-repo-base-source');
-    const hint = document.getElementById('vc-repo-base-hint');
-    if (badge) badge.classList.toggle('d-none', !fromGithub);
-    if (hint) hint.classList.toggle('d-none', !fromGithub);
-}
-
-function _applyBriefingUrlFromRoadmap(selectValue) {
-    const briefingEl = document.getElementById('vc-briefing-url');
-    if (!briefingEl) return;
-    const roadmapUrl = selectValue && window._projectUrlMap ? window._projectUrlMap[selectValue] : '';
-    if (roadmapUrl) {
-        briefingEl.value = roadmapUrl;
-        _setBriefingSourceBadge(true);
-    } else {
-        // Only clear if currently showing a roadmap URL (don't wipe manually entered values)
-        const badge = document.getElementById('vc-briefing-source');
-        if (badge && !badge.classList.contains('d-none')) {
-            briefingEl.value = '';
-        }
-        _setBriefingSourceBadge(false);
-    }
-}
-
-async function saveVirtualClassroom(isActive) {
-    const selectEl = document.getElementById('vc-project-select');
-    const repoBaseEl = document.getElementById('vc-repo-base');
-    const briefingEl = document.getElementById('vc-briefing-url');
-    const dueDateEl = document.getElementById('vc-due-date');
-    const statusBadge = document.getElementById('vc-status-badge');
-    const deactivateBtn = document.getElementById('vc-deactivate-btn');
-    const activateBtn = document.getElementById('vc-activate-btn');
-
-    if (!selectEl || !repoBaseEl || !briefingEl || !statusBadge || !deactivateBtn || !activateBtn) return;
-
-    const value = selectEl.value;
-    if (!value && isActive) {
-        showToast('Selecciona un proyecto antes de activar el Aula Virtual', 'danger');
-        return;
-    }
-
-    const [moduleId, projectName] = value ? value.split('__') : ['', ''];
+    const repoBaseUrl = card.querySelector('.vc-repo-base-input')?.value || '';
+    const briefingUrl = card.querySelector('.vc-briefing-input')?.value || '';
+    const dueDate = card.querySelector('.vc-due-date-input')?.value || null;
 
     // Derive project type from saved evaluations if exists (fallback: individual)
     const savedEvaluations = window._evalState.savedEvaluations || [];
@@ -11515,8 +11448,31 @@ async function saveVirtualClassroom(isActive) {
     const existingEval = savedEvaluations.find(e => e.projectName === projectName);
     const projectType = existingEval ? (existingEval.type || 'individual') : 'individual';
 
-    // Prepare current enriched competences from _evalState to sync with DB
-    // IMPORTANT: Only sync the actual program competences (preventing the full catalog save)
+    const entry = { isActive: !!isActive, moduleId: modId, projectName, projectType, repoBaseUrl, briefingUrl, dueDate };
+
+    if (!window._evalState.virtualClassrooms) window._evalState.virtualClassrooms = [];
+    const idx = window._evalState.virtualClassrooms.findIndex(
+        v => v && String(v.moduleId) === String(modId) && v.projectName === projectName
+    );
+    if (idx >= 0) window._evalState.virtualClassrooms[idx] = entry;
+    else window._evalState.virtualClassrooms.push(entry);
+
+    card.querySelectorAll('button').forEach(b => { b.disabled = true; });
+
+    const ok = await _persistVirtualClassrooms();
+
+    if (ok) {
+        showToast(isActive ? 'Aula Virtual activada/actualizada correctamente' : 'Aula Virtual desactivada para este proyecto', 'success');
+    } else {
+        showToast('Error al guardar la configuración del Aula Virtual', 'danger');
+    }
+    _renderVirtualClassroomList();
+};
+
+async function _persistVirtualClassrooms() {
+    // Prepare current enriched competences from _evalState to sync with DB alongside the change —
+    // el endpoint público de Aula Virtual resuelve competencias/herramientas contra ext.competences,
+    // así que se mantiene fresco en cada guardado (igual que hacía el flujo anterior de un solo proyecto).
     const syncComps = (window._evalState.programCompetences || []).map(c => ({
         id: c.id, name: c.name, area: c.area, description: c.description || '',
         levels: c.levels || [], allTools: c.allTools || [],
@@ -11525,78 +11481,30 @@ async function saveVirtualClassroom(isActive) {
         competenceIndicators: c.competenceIndicators || { initial: [], medio: [], advance: [] }
     }));
 
-    const body = {
-        competences: syncComps,
-        virtualClassroom: {
-            isActive: !!isActive,
-            moduleId,
-            projectName,
-            projectType,
-            repoBaseUrl: repoBaseEl.value || '',
-            briefingUrl: briefingEl.value || '',
-            dueDate: (dueDateEl && dueDateEl.value) ? dueDateEl.value : null
-        }
-    };
-
     const token = localStorage.getItem('token');
-    activateBtn.disabled = true;
-    deactivateBtn.disabled = true;
-
     try {
         const res = await fetch(`${API_URL}/api/promotions/${promotionId}/extended-info`, {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${token}`
-            },
-            body: JSON.stringify(body)
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+            body: JSON.stringify({ competences: syncComps, virtualClassrooms: window._evalState.virtualClassrooms })
         });
-
         if (!res.ok) {
             const err = await res.json().catch(() => ({}));
-            console.error('Error saving virtual classroom:', err);
-            showToast('Error al guardar la configuración del Aula Virtual', 'danger');
-            return;
+            console.error('[_persistVirtualClassrooms] Error:', err);
+            return false;
         }
-
         const updated = await res.json();
-        window._evalState.virtualClassroom = updated.virtualClassroom || body.virtualClassroom;
-        
-        // Sync with global extendedInfoData to prevent stale overwrites on next "Guardar Todos los Cambios"
+        window._evalState.virtualClassrooms = updated.virtualClassrooms || window._evalState.virtualClassrooms;
         if (typeof extendedInfoData !== 'undefined') {
-            extendedInfoData.virtualClassroom = window._evalState.virtualClassroom;
-            if (updated.competences) {
-                extendedInfoData.competences = updated.competences;
-            }
+            extendedInfoData.virtualClassrooms = window._evalState.virtualClassrooms;
+            if (updated.competences) extendedInfoData.competences = updated.competences;
         }
-
-        if (body.virtualClassroom.isActive && moduleId && projectName) {
-            statusBadge.textContent = `Proyecto activo: ${projectName}`;
-            statusBadge.className = 'badge bg-success';
-            deactivateBtn.disabled = false;
-            activateBtn.innerHTML = '<i class="bi bi-arrow-repeat me-1"></i>Actualizar Aula Virtual';
-            showToast('Aula Virtual activada/actualizada correctamente', 'success');
-        } else {
-            statusBadge.textContent = 'Sin proyecto activo';
-            statusBadge.className = 'badge bg-secondary';
-            deactivateBtn.disabled = true;
-            activateBtn.innerHTML = '<i class="bi bi-play-circle me-1"></i>Activar Aula Virtual';
-            showToast('Aula Virtual desactivada', 'success');
-        }
+        return true;
     } catch (err) {
-        console.error('Error saving virtual classroom:', err);
-        showToast('Error de conexión al guardar Aula Virtual', 'danger');
-    } finally {
-        activateBtn.disabled = false;
-        if (window._evalState.virtualClassroom && window._evalState.virtualClassroom.isActive) {
-            deactivateBtn.disabled = false;
-        }
+        console.error('[_persistVirtualClassrooms] Exception:', err);
+        return false;
     }
 }
-
-window.deactivateVirtualClassroom = function () {
-    saveVirtualClassroom(false);
-};
 
 function renderEvaluationTab() {
     const container = document.getElementById('evaluation-content');


### PR DESCRIPTION
## Problema
El Aula Virtual solo dejaba activar **un** proyecto a la vez para toda la promoción. Cuando un proyecto final tiene varios briefings distintos según la especialización elegida por el estudiantado (por ejemplo Desarrollo Web / Data & ML / Agentes-IA), el profesorado tenía que desactivar el proyecto de una especialización para activar el de otra — el estudiantado de la primera se quedaba sin poder entregar.

Va de la mano con el PR del backend: proyectof5/bootcamp-manager-server#15 (nuevo campo `virtualClassrooms`, array, y los 3 endpoints de Aula Virtual actualizados para trabajar con varios proyectos activos).

## Cambio

**Panel del profesorado** (Contenido del Programa → Aula Virtual):
- [VirtualClassroomPanel.tsx](app/promotion/_components/VirtualClassroomPanel.tsx) ya no es un formulario de un solo proyecto (`<select>` + inputs); ahora es un shell con un contenedor (`#vc-projects-list`) que puebla el orquestador legacy — mismo patrón que el resto de paneles de esta página.
- [promotion-detail.js](public/js/promotion-detail.js): `initVirtualClassroomPanel`/`_renderVirtualClassroomList` sustituyen al flujo de un solo proyecto. Cada proyecto definido en Evaluación (`projectCompetences`) tiene su propia fila con sus propios campos (URL de repo, briefing, fecha de entrega) y su propio botón activar/actualizar/desactivar (`window._vcToggleProject`) — activar o desactivar uno no toca a los demás.

**Vista pública del estudiantado**:
- [types.ts](app/public-promotion/_components/types.ts): `PPVirtualClassroom` (un proyecto + `active`) → `PPVCProject` (un proyecto) + `PPVirtualClassroomResponse` (`active` + `projects[]`).
- [page.tsx](app/public-promotion/page.tsx): guarda el array de proyectos activos; el botón "Ir al Aula Virtual" indica cuántos hay activos.
- [AulaVirtual.tsx](app/public-promotion/_components/AulaVirtual.tsx): si hay más de un proyecto activo, primero pide elegir a cuál se va a entregar (esta página pública no tiene login, así que no hay forma de adivinarlo automáticamente) y luego reutiliza la vista de siempre para ese proyecto, con un botón "Cambiar de proyecto". Las llamadas a `submissions` ahora incluyen `moduleId`+`projectName` para que el backend sepa a cuál de los proyectos activos corresponde cada entrega.

## Verificación
- `tsc --noEmit` limpio, `node -c` sobre el JS legacy editado sin errores de sintaxis.
- Probado en local (frontend + backend + base de datos real): activé "App con Python" (individual) y "CRUD con Python" (grupal) a la vez en la misma promoción. Confirmado por captura y por texto de página que:
  - El panel del profesorado muestra ambos como "Activo" de forma independiente, cada uno con su propio briefing/competencias/fecha.
  - La vista pública del estudiantado ofrece un selector con los 2 proyectos; entrando a cada uno se ve su propio briefing, sus propias competencias/herramientas y su propio tipo de entrega (grupal vs. individual), sin mezclarse entre sí.
  - Sin errores en consola en ninguna de las dos vistas.