### PR TITLE
feat: Gantt editable por día + exportar roadmap (PNG/PDF/XLSX)

### DIFF
--- a/app/promotion/_components/RoadmapPanel.tsx
+++ b/app/promotion/_components/RoadmapPanel.tsx
@@ -28,7 +28,7 @@
  * está disponible (poll corto) para garantizar el render tras el montaje.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -55,6 +55,46 @@ export function RoadmapPanelHost() {
   const host = usePortalNode('program-details-roadmap');
   if (!host) return null;
   return createPortal(<RoadmapPanel />, host);
+}
+
+// Dropdown "Descargar" con estado propio (useState + click-fuera para cerrar) en vez de
+// data-bs-toggle="dropdown": esta página no carga el JS de Bootstrap (solo su CSS), así que
+// data-bs-toggle no hace nada por sí solo — se comprobó en vivo (window.bootstrap === undefined).
+function ExportDropdown() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onEsc = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onEsc);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onEsc);
+    };
+  }, [open]);
+
+  const pick = (format: 'png' | 'pdf' | 'xlsx') => {
+    setOpen(false);
+    w().exportRoadmap?.(format);
+  };
+
+  return (
+    <div className="dropdown" ref={ref} style={{ position: 'relative' }}>
+      <button type="button" className="btn btn-outline-primary btn-sm dropdown-toggle" aria-expanded={open} onClick={() => setOpen((o) => !o)}>
+        <i className="bi bi-download me-1" />Descargar
+      </button>
+      <ul className={`dropdown-menu dropdown-menu-end${open ? ' show' : ''}`} style={{ position: 'absolute', right: 0 }}>
+        <li><button type="button" className="dropdown-item" onClick={() => pick('png')}><i className="bi bi-file-earmark-image me-2" />Imagen (PNG)</button></li>
+        <li><button type="button" className="dropdown-item" onClick={() => pick('pdf')}><i className="bi bi-file-earmark-pdf me-2" />PDF</button></li>
+        <li><button type="button" className="dropdown-item" onClick={() => pick('xlsx')}><i className="bi bi-file-earmark-excel me-2" />Excel (XLSX)</button></li>
+      </ul>
+    </div>
+  );
 }
 
 function RoadmapPanel() {
@@ -87,12 +127,15 @@ function RoadmapPanel() {
         {/* Lo puebla el legacy (displayModules) por innerHTML. */}
       </div>
       <div className="mt-4">
-        <div className="d-flex justify-content-between align-items-center mb-3">
+        <div className="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
           <h6 className="mb-0">Diagrama Gantt</h6>
-          <div className="btn-group btn-group-sm" role="group" aria-label="Zoom del Gantt">
-            <button type="button" className="btn btn-outline-secondary gantt-zoom-btn" data-zoom-level="day" onClick={() => w().setGanttZoomLevel?.('day')}>Día</button>
-            <button type="button" className="btn btn-outline-secondary gantt-zoom-btn active" data-zoom-level="week" onClick={() => w().setGanttZoomLevel?.('week')}>Semana</button>
-            <button type="button" className="btn btn-outline-secondary gantt-zoom-btn" data-zoom-level="month" onClick={() => w().setGanttZoomLevel?.('month')}>Mes</button>
+          <div className="d-flex gap-2">
+            <div className="btn-group btn-group-sm" role="group" aria-label="Zoom del Gantt">
+              <button type="button" className="btn btn-outline-secondary gantt-zoom-btn" data-zoom-level="day" onClick={() => w().setGanttZoomLevel?.('day')}>Día</button>
+              <button type="button" className="btn btn-outline-secondary gantt-zoom-btn active" data-zoom-level="week" onClick={() => w().setGanttZoomLevel?.('week')}>Semana</button>
+              <button type="button" className="btn btn-outline-secondary gantt-zoom-btn" data-zoom-level="month" onClick={() => w().setGanttZoomLevel?.('month')}>Mes</button>
+            </div>
+            <ExportDropdown />
           </div>
         </div>
         {/* Lo puebla el legacy (generateGanttChart → DHTMLX Gantt, Fase 6). */}

--- a/public/js/gantt-adapter.js
+++ b/public/js/gantt-adapter.js
@@ -317,9 +317,69 @@ window.buildGanttDataset = buildGanttDataset;
 window.formatGanttDate = formatGanttDate;
 window.GANTT_DATE_FORMAT = GANTT_DATE_FORMAT;
 
+const GANTT_ITEM_TYPE_LABELS = {
+    module: 'Módulo',
+    course: 'Curso',
+    project: 'Proyecto',
+    leccion: 'Lección',
+    flexible: 'Tiempo flexible',
+};
+
+/**
+ * Construye filas planas (una por módulo/curso/proyecto/lección/bloque de
+ * tiempo flexible) listas para exportar a Excel — reutiliza el mismo dataset
+ * que alimenta el Gantt (`buildGanttDataset`), así que las fechas exportadas
+ * son exactamente las que se ven dibujadas.
+ * @param {Object} promotion
+ * @returns {Array<{Módulo: string, Elemento: string, Tipo: string, Inicio: string, Fin: string, 'Duración (días)': number}>}
+ */
+function buildRoadmapExportRows(promotion) {
+    const { data } = buildGanttDataset(promotion);
+    const moduleNameByIndex = {};
+    data.forEach(row => {
+        if (row.itemType === 'module') moduleNameByIndex[row.itemIndex] = row.text;
+    });
+
+    return data
+        .filter(row => row.itemType !== 'leccion-group')
+        .map(row => {
+            // start_date viene en formato "%d-%m-%Y" (GANTT_DATE_FORMAT) — se
+            // parsea a mano para no depender de que dhtmlxgantt esté cargado.
+            const [dd, mm, yyyy] = row.start_date.split('-').map(Number);
+            const startDate = new Date(yyyy, mm - 1, dd);
+            const durationDays = Math.max(1, Math.round(row.duration));
+            const endDate = addDays(startDate, durationDays - 1); // último día activo (inclusive)
+
+            const fmt = (d) => d.toLocaleDateString('es-ES', { day: '2-digit', month: '2-digit', year: 'numeric' });
+
+            return {
+                'Módulo': row.itemType === 'module' ? row.text : (moduleNameByIndex[row.moduleIndex] || ''),
+                'Elemento': row.itemType === 'module' ? '' : row.text,
+                'Tipo': GANTT_ITEM_TYPE_LABELS[row.itemType] || row.itemType,
+                'Inicio': fmt(startDate),
+                'Fin': fmt(endDate),
+                'Duración (días)': durationDays,
+            };
+        });
+}
+
+window.buildRoadmapExportRows = buildRoadmapExportRows;
+
 /**
  * Traduce el cambio hecho por el docente (drag/resize) sobre una tarea del
  * Gantt de vuelta al modelo de dominio de la promoción (in-place).
+ *
+ * Precisión por día: `startOffset`/`duration` siguen expresándose en la misma
+ * unidad de siempre ("semanas absolutas desde `promotion.startDate`"), pero
+ * ya NO se redondean a la semana completa más cercana — se redondea al DÍA
+ * más cercano y se expresa como fracción de semana (p.ej. 15 días = 15/7
+ * semanas). Como `buildGanttDataset()`/`getModuleStartWeeks()`/
+ * `getItemStartWeeks()` ya multiplican esta misma cifra por 7 para obtener
+ * días, esto basta para que el Gantt (en cualquier zoom, incluido "Día")
+ * refleje y persista posiciones/duraciones con precisión de un día, sin tocar
+ * el resto del pipeline de lectura/render ni los datos de promociones
+ * existentes (un valor entero de semanas sigue significando exactamente lo
+ * mismo que antes — es un caso particular de esta misma fracción).
  *
  * Reglas de negocio (siguen la misma convención que el Gantt original):
  * - Módulos: se puede cambiar tanto su posición (`startOffset`, semanas
@@ -347,16 +407,18 @@ function applyGanttTaskChange(promotion, task) {
     if (!promotion || !task) return false;
 
     const baseDate = promotion.startDate ? new Date(promotion.startDate) : new Date();
-    const startDays = Math.round((task.start_date - baseDate) / 86400000);
-    const durationDays = Number(task.duration) || 1;
-    const durationWeeks = Math.max(1, Math.round(durationDays / 7));
+    // Redondeo al día (no a la semana): así el Gantt es editable día a día en
+    // cualquier zoom, no solo en semana completa.
+    const startDaysRounded = Math.round((task.start_date - baseDate) / 86400000);
+    const durationDaysRounded = Math.max(1, Math.round(Number(task.duration) || 1));
+    const startWeeksPrecise = Math.max(0, startDaysRounded) / 7;
+    const durationWeeksPrecise = durationDaysRounded / 7;
 
     if (task.itemType === 'module') {
         const module = (promotion.modules || [])[task.itemIndex];
         if (!module) return false;
-        const startWeeks = Math.max(0, Math.round(startDays / 7));
-        module.startOffset = startWeeks;
-        module.duration = durationWeeks;
+        module.startOffset = startWeeksPrecise;
+        module.duration = durationWeeksPrecise;
         return true;
     }
 
@@ -364,9 +426,8 @@ function applyGanttTaskChange(promotion, task) {
         const block = (promotion.flexibleBlocks || []).find(b => b.id === task.flexibleBlockId);
         if (!block) return false;
 
-        const startWeeks = Math.max(0, Math.round(startDays / 7));
-        block.startOffset = startWeeks;
-        block.duration = durationWeeks;
+        block.startOffset = startWeeksPrecise;
+        block.duration = durationWeeksPrecise;
         return true;
     }
 
@@ -382,13 +443,13 @@ function applyGanttTaskChange(promotion, task) {
         // Fase 5: la posición se guarda como semana ABSOLUTA (independiente del
         // módulo), no relativa. `startOffset` legacy ya no se escribe en este
         // flujo — se conserva tal cual para lectura de compatibilidad (TASK-19).
-        const absoluteStartOffset = Math.max(0, Math.round(startDays / 7));
+        const absoluteStartOffset = startWeeksPrecise;
 
         if (Array.isArray(module.plannerItems) && module.plannerItems.length > 0 && task.plannerItemId) {
             const plannerItem = module.plannerItems.find(i => i.id === task.plannerItemId);
             if (!plannerItem) return false;
 
-            plannerItem.duration = durationWeeks;
+            plannerItem.duration = durationWeeksPrecise;
             plannerItem.absoluteStartOffset = absoluteStartOffset;
 
             // Resincroniza los arrays legacy derivados (mismo criterio que
@@ -409,9 +470,9 @@ function applyGanttTaskChange(promotion, task) {
 
         const current = list[task.legacyIndex];
         if (typeof current === 'string') {
-            list[task.legacyIndex] = { name: current, duration: durationWeeks, absoluteStartOffset };
+            list[task.legacyIndex] = { name: current, duration: durationWeeksPrecise, absoluteStartOffset };
         } else {
-            current.duration = durationWeeks;
+            current.duration = durationWeeksPrecise;
             current.absoluteStartOffset = absoluteStartOffset;
         }
         return true;

--- a/public/js/promotion-detail.js
+++ b/public/js/promotion-detail.js
@@ -3596,6 +3596,151 @@ function setGanttZoomLevel(level) {
 }
 
 /**
+ * Descarga el roadmap actual en el formato pedido — 'png'/'pdf' (captura visual
+ * del diagrama Gantt completo) o 'xlsx' (tabla módulo/elemento/fechas). Las
+ * librerías (html2canvas, jsPDF, SheetJS) ya se cargan globalmente desde
+ * app/promotion/page.tsx.
+ * @param {'png'|'pdf'|'xlsx'} format
+ */
+async function exportRoadmap(format) {
+    if (typeof gantt === 'undefined' || !_ganttInitialized) {
+        showToast('El Gantt no está listo todavía.', 'warning');
+        return;
+    }
+
+    const token = localStorage.getItem('token');
+    let promotion;
+    try {
+        const res = await fetch(`${API_URL}/api/promotions/${promotionId}`, { headers: { 'Authorization': `Bearer ${token}` } });
+        if (!res.ok) throw new Error('No se pudo cargar la promoción');
+        promotion = await res.json();
+    } catch (err) {
+        console.error('[exportRoadmap]', err);
+        showToast('Error al cargar los datos del roadmap', 'danger');
+        return;
+    }
+
+    if (format === 'xlsx') {
+        _exportRoadmapXlsx(promotion);
+    } else if (format === 'png' || format === 'pdf') {
+        await _exportRoadmapImage(promotion, format);
+    }
+}
+window.exportRoadmap = exportRoadmap;
+
+function _exportRoadmapXlsx(promotion) {
+    if (typeof XLSX === 'undefined' || typeof window.buildRoadmapExportRows !== 'function') {
+        showToast('No se pudo cargar la librería de exportación (Excel).', 'danger');
+        return;
+    }
+    const rows = window.buildRoadmapExportRows(promotion);
+    if (!rows.length) {
+        showToast('El roadmap no tiene módulos que exportar todavía.', 'warning');
+        return;
+    }
+    const ws = XLSX.utils.json_to_sheet(rows);
+    ws['!cols'] = [{ wch: 28 }, { wch: 36 }, { wch: 14 }, { wch: 12 }, { wch: 12 }, { wch: 16 }];
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Roadmap');
+    XLSX.writeFile(wb, `roadmap-${_exportSafeFileName(promotion.name)}.xlsx`);
+    showToast('Roadmap exportado a Excel ✓', 'success');
+}
+
+/**
+ * Exporta el Gantt como imagen (PNG) o incrustada en un PDF (una página,
+ * apaisada si el diagrama es más ancho que alto). Fuerza temporalmente el
+ * contenedor a su tamaño de contenido completo (sin scroll ni virtualización)
+ * para que la captura incluya TODAS las filas/columnas, no solo lo visible en
+ * pantalla — y restaura el tamaño/estado original al terminar, incluso si algo falla.
+ * @param {Object} promotion
+ * @param {'png'|'pdf'} format
+ */
+async function _exportRoadmapImage(promotion, format) {
+    if (typeof html2canvas === 'undefined') {
+        showToast('No se pudo cargar la librería de exportación (imagen).', 'danger');
+        return;
+    }
+    const container = document.getElementById('gantt-container');
+    if (!container) return;
+
+    showToast(`Generando ${format === 'pdf' ? 'PDF' : 'imagen'} del roadmap…`, 'info');
+
+    const prevSmartRendering = gantt.config.smart_rendering;
+    const prevWidth = container.style.width;
+    const prevHeight = container.style.height;
+    const prevOverflow = container.style.overflow;
+
+    try {
+        gantt.config.smart_rendering = false;
+        gantt.scrollTo(0, 0);
+        gantt.render();
+        await new Promise(r => setTimeout(r, 30));
+
+        const dataArea = gantt.$task_data || container.querySelector('.gantt_data_area');
+        const gridArea = container.querySelector('.gantt_grid');
+        const fullWidth = Math.max(
+            container.scrollWidth,
+            (gridArea ? gridArea.offsetWidth : 0) + (dataArea ? dataArea.scrollWidth : 0)
+        );
+        const fullHeight = Math.max(container.scrollHeight, dataArea ? dataArea.scrollHeight : 0, 200);
+
+        container.style.width = `${fullWidth}px`;
+        container.style.height = `${fullHeight}px`;
+        container.style.overflow = 'visible';
+        gantt.setSizes();
+        await new Promise(r => setTimeout(r, 30));
+
+        const canvas = await html2canvas(container, {
+            width: fullWidth,
+            height: fullHeight,
+            windowWidth: fullWidth,
+            windowHeight: fullHeight,
+            scale: 2,
+            backgroundColor: '#ffffff',
+            useCORS: true,
+        });
+
+        const safeName = _exportSafeFileName(promotion.name);
+
+        if (format === 'png') {
+            const link = document.createElement('a');
+            link.download = `roadmap-${safeName}.png`;
+            link.href = canvas.toDataURL('image/png');
+            link.click();
+        } else {
+            const { jsPDF } = window.jspdf;
+            const imgData = canvas.toDataURL('image/png');
+            const pxToMm = 25.4 / 96; // 96dpi; canvas viene a scale:2, se compensa /2 abajo
+            const pdfWidth = (canvas.width / 2) * pxToMm;
+            const pdfHeight = (canvas.height / 2) * pxToMm;
+            const pdf = new jsPDF({
+                orientation: pdfWidth > pdfHeight ? 'landscape' : 'portrait',
+                unit: 'mm',
+                format: [pdfWidth, pdfHeight]
+            });
+            pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
+            pdf.save(`roadmap-${safeName}.pdf`);
+        }
+
+        showToast('Roadmap exportado ✓', 'success');
+    } catch (err) {
+        console.error('[exportRoadmap]', err);
+        showToast('Error al exportar el roadmap', 'danger');
+    } finally {
+        gantt.config.smart_rendering = prevSmartRendering;
+        container.style.width = prevWidth;
+        container.style.height = prevHeight;
+        container.style.overflow = prevOverflow;
+        gantt.setSizes();
+        gantt.render();
+    }
+}
+
+function _exportSafeFileName(name) {
+    return (name || 'roadmap').trim().replace(/[^\w-]+/g, '_').replace(/^_+|_+$/g, '') || 'roadmap';
+}
+
+/**
  * Registra los listeners que permiten editar el Gantt arrastrando/redimensionando
  * tareas y persisten el cambio contra la API. Módulos, cursos, proyectos y
  * lecciones se pueden mover y redimensionar libremente.


### PR DESCRIPTION
## 1. Gantt editable por día

**Problema**: arrastrar o redimensionar cualquier elemento del Gantt (módulo, curso, proyecto, lección, tiempo flexible) se guardaba siempre redondeado a la semana completa más cercana, sin importar el zoom ("Día"/"Semana"/"Mes") — mover una tarea unos días en la vista "Día" se deshacía al soltar.

**Causa**: [`applyGanttTaskChange()`](public/js/gantt-adapter.js) hacía `Math.round(startDays / 7)` / `Math.round(durationDays / 7)` incondicionalmente.

**Fix**: redondea al día más cercano y lo expresa como fracción de semana (15 días = 15/7 semanas). El resto del pipeline de lectura/render (`buildGanttDataset`, `getModuleStartWeeks`, `getItemStartWeeks`) ya multiplica ese mismo valor por 7 para reconstruir los días exactos — así que no hace falta tocar nada más, y **las promociones existentes no se ven afectadas** (un entero de semanas sigue significando exactamente lo mismo: es un caso particular de esta misma fracción). Cambio quirúrgico y retrocompatible por diseño, sin migración de datos.

## 2. Exportar roadmap (PNG / PDF / XLSX)

Nuevo botón **"Descargar"** en Roadmap & Módulos, junto al zoom del Gantt:
- **XLSX**: tabla módulo/elemento/tipo/inicio/fin/duración, reutilizando el mismo dataset que dibuja el Gantt (mismas fechas).
- **PNG**: captura del diagrama Gantt COMPLETO (todas las filas y meses, no solo lo visible en pantalla) — se logra desactivando temporalmente la virtualización y expandiendo el contenedor a su tamaño de contenido real antes de capturar con html2canvas, restaurando todo al terminar.
- **PDF**: la misma captura incrustada en una página con jsPDF.

No se añaden dependencias nuevas — SheetJS/html2canvas/jsPDF ya se cargaban globalmente para el Syllabus.

El menú "Descargar" es un dropdown con estado propio (no `data-bs-toggle`, que no habría funcionado: esta página no carga el JS de Bootstrap, se comprobó en vivo que `window.bootstrap === undefined`).

## Verificación

- `tsc --noEmit` y `node -c` limpios en ambos archivos JS tocados.
- Simulé un arrastre de 3 días sobre una tarea real y confirmé que `absoluteStartOffset` queda en `3/7` semanas, y que reconstruir la fecha desde ese valor da exactamente el día arrastrado (antes volvía a 0).
- `exportRoadmap('xlsx')` genera un libro de 18 filas con fechas correctas.
- `exportRoadmap('png')` genera un canvas de 3198×1296px (scale 2) — inspeccioné el PNG resultante y contiene el Gantt completo (todos los módulos, semanas, marcador "Hoy"), no recortado a los 500px de alto del contenedor visible.
- `exportRoadmap('pdf')` corre sin errores sobre la misma captura.
- El dropdown "Descargar" abre/cierra correctamente y sus 3 opciones son alcanzables.
- Sin errores nuevos en consola.