### PR TITLE
fix: el botón 'Exportar roadmap' no abría el menú (ningún navegador)

### DIFF
--- a/app/promotion/_components/RoadmapPanel.tsx
+++ b/app/promotion/_components/RoadmapPanel.tsx
@@ -61,11 +61,21 @@ export function RoadmapPanelHost() {
 // data-bs-toggle="dropdown": esta página no carga el JS de Bootstrap (solo su CSS), así que
 // data-bs-toggle no hace nada por sí solo — se comprobó en vivo (window.bootstrap === undefined).
 //
-// Evita deliberadamente la palabra "Descargar"/"Download" y el icono de flecha-hacia-abajo: los
-// bloqueadores de anuncios (Brave Shields, uBlock, AdBlock...) traen filtros cosméticos genéricos
-// que ocultan botones así por parecerse al patrón de "botón de descarga falso" tan común en
-// publicidad maliciosa — un usuario reportó que en Brave el menú ni siquiera se abría, y la lógica
-// de exportación en sí ya estaba verificada como correcta (sin errores llamándola directamente).
+// Causa raíz real de "el menú no se abre" (reproducida en dev Y en el export estático de
+// producción, en cualquier navegador — no es cosa de bloqueadores de anuncios): shared.js trae un
+// shim de Bootstrap (_bootstrapJsShim) que, en CADA clic de la página, cierra todo
+// `.dropdown-menu.show` cuyo disparador no tenga `data-bs-toggle="dropdown"` — mi botón React no
+// lo tiene, así que el propio clic que abre el menú (vía setOpen(true) más arriba en la cadena)
+// burbujea hasta `document` y el shim le quita `show` a la clase en el mismo evento, dejando
+// aria-expanded="true" (lo último que tocó React) pero la clase sin "show" (lo último que tocó el
+// shim). e.stopPropagation() en el botón evita que ESE clic llegue al listener del shim; los clics
+// fuera del menú (que sí deben cerrarlo) no lo llevan y siguen funcionando via el propio listener
+// de abajo (mousedown) y, redundantemente, via el shim.
+//
+// Se evita además la palabra "Descargar"/"Download" y el icono de flecha-hacia-abajo por si acaso:
+// los bloqueadores de anuncios (Brave Shields, uBlock...) traen filtros cosméticos genéricos que
+// ocultan botones así por parecerse al patrón de "botón de descarga falso" tan común en publicidad
+// maliciosa — no era la causa real de este bug, pero es una defensa razonable de todos modos.
 function ExportDropdown() {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -84,20 +94,26 @@ function ExportDropdown() {
     };
   }, [open]);
 
-  const pick = (format: 'png' | 'pdf' | 'xlsx') => {
+  const pick = (e: React.MouseEvent, format: 'png' | 'pdf' | 'xlsx') => {
+    e.stopPropagation(); // ver comentario arriba: evita que shared.js cierre/reabra por su cuenta
     setOpen(false);
     w().exportRoadmap?.(format);
   };
 
   return (
     <div className="roadmap-export-menu" ref={ref} style={{ position: 'relative' }}>
-      <button type="button" className="btn btn-outline-primary btn-sm" aria-expanded={open} onClick={() => setOpen((o) => !o)}>
+      <button
+        type="button"
+        className="btn btn-outline-primary btn-sm"
+        aria-expanded={open}
+        onClick={(e) => { e.stopPropagation(); setOpen((o) => !o); }}
+      >
         <i className="bi bi-box-arrow-up-right me-1" />Exportar roadmap
       </button>
       <ul className={`dropdown-menu dropdown-menu-end${open ? ' show' : ''}`} style={{ position: 'absolute', right: 0 }}>
-        <li><button type="button" className="dropdown-item" onClick={() => pick('png')}><i className="bi bi-file-earmark-image me-2" />Imagen (PNG)</button></li>
-        <li><button type="button" className="dropdown-item" onClick={() => pick('pdf')}><i className="bi bi-file-earmark-pdf me-2" />PDF</button></li>
-        <li><button type="button" className="dropdown-item" onClick={() => pick('xlsx')}><i className="bi bi-file-earmark-excel me-2" />Excel (XLSX)</button></li>
+        <li><button type="button" className="dropdown-item" onClick={(e) => pick(e, 'png')}><i className="bi bi-file-earmark-image me-2" />Imagen (PNG)</button></li>
+        <li><button type="button" className="dropdown-item" onClick={(e) => pick(e, 'pdf')}><i className="bi bi-file-earmark-pdf me-2" />PDF</button></li>
+        <li><button type="button" className="dropdown-item" onClick={(e) => pick(e, 'xlsx')}><i className="bi bi-file-earmark-excel me-2" />Excel (XLSX)</button></li>
       </ul>
     </div>
   );

--- a/app/promotion/_components/RoadmapPanel.tsx
+++ b/app/promotion/_components/RoadmapPanel.tsx
@@ -57,9 +57,15 @@ export function RoadmapPanelHost() {
   return createPortal(<RoadmapPanel />, host);
 }
 
-// Dropdown "Descargar" con estado propio (useState + click-fuera para cerrar) en vez de
+// Dropdown de exportación con estado propio (useState + click-fuera para cerrar) en vez de
 // data-bs-toggle="dropdown": esta página no carga el JS de Bootstrap (solo su CSS), así que
 // data-bs-toggle no hace nada por sí solo — se comprobó en vivo (window.bootstrap === undefined).
+//
+// Evita deliberadamente la palabra "Descargar"/"Download" y el icono de flecha-hacia-abajo: los
+// bloqueadores de anuncios (Brave Shields, uBlock, AdBlock...) traen filtros cosméticos genéricos
+// que ocultan botones así por parecerse al patrón de "botón de descarga falso" tan común en
+// publicidad maliciosa — un usuario reportó que en Brave el menú ni siquiera se abría, y la lógica
+// de exportación en sí ya estaba verificada como correcta (sin errores llamándola directamente).
 function ExportDropdown() {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -84,9 +90,9 @@ function ExportDropdown() {
   };
 
   return (
-    <div className="dropdown" ref={ref} style={{ position: 'relative' }}>
-      <button type="button" className="btn btn-outline-primary btn-sm dropdown-toggle" aria-expanded={open} onClick={() => setOpen((o) => !o)}>
-        <i className="bi bi-download me-1" />Descargar
+    <div className="roadmap-export-menu" ref={ref} style={{ position: 'relative' }}>
+      <button type="button" className="btn btn-outline-primary btn-sm" aria-expanded={open} onClick={() => setOpen((o) => !o)}>
+        <i className="bi bi-box-arrow-up-right me-1" />Exportar roadmap
       </button>
       <ul className={`dropdown-menu dropdown-menu-end${open ? ' show' : ''}`} style={{ position: 'absolute', right: 0 }}>
         <li><button type="button" className="dropdown-item" onClick={() => pick('png')}><i className="bi bi-file-earmark-image me-2" />Imagen (PNG)</button></li>


### PR DESCRIPTION
## Problema
El menú del botón "Descargar"/"Exportar roadmap" del Roadmap no se abría al hacer clic — reportado en Brave, pero **reproducido también en Chrome contra el export estático de producción** (`npm run build && serve out`), con clic real (no invocado por JS). No es cosa de bloqueadores de anuncios.

## Causa real
[shared.js](public/js/shared.js) trae un shim de Bootstrap (`_bootstrapJsShim`) porque esta página no carga el JS real de Bootstrap (solo su CSS, confirmado en vivo: `window.bootstrap === undefined`). En **cada clic de la página**, ese shim cierra todo `.dropdown-menu.show` cuyo disparador no tenga `data-bs-toggle="dropdown"`:

```js
document.querySelectorAll('.dropdown-menu.show').forEach((m) => {
  const host = m.closest('.dropdown, .btn-group');
  if (!dTrigger || !host || !host.contains(dTrigger)) m.classList.remove('show');
});
```

El botón de `ExportDropdown` (introducido en #42) es un dropdown 100% en React y no tiene ese atributo. Así que el propio clic que lo abre (el `setOpen(true)`) burbujea hasta `document`, y el shim le quita la clase `show` **en el mismo evento**: React deja `aria-expanded="true"` (lo último que tocó) pero el `<ul>` sin `show` (lo último que tocó el shim, después) — el menú nunca llega a pintarse abierto, aunque el estado de React sea correcto.

## Fix
`e.stopPropagation()` en el botón y en los 3 items del menú, para que esos clics no lleguen al listener global del shim. Los clics *fuera* del menú (que sí deben cerrarlo) no lo llevan y lo siguen cerrando bien vía el listener de `mousedown` que ya tenía el componente.

De paso se mantiene el cambio de la rama anterior (renombrar "Descargar" → "Exportar roadmap", icono neutro) — no era la causa real, pero es una defensa razonable contra bloqueadores de anuncios de todos modos.

## Verificación
Reproduje el bug y lo verifiqué arreglado contra el **export estático de producción real** (`next build` + `serve out`, sin dev server), con clics reales:
- Antes del fix: `aria-expanded="true"` pero el `<ul>` sin la clase `show` (menú invisible) — confirmado con un listener de diagnóstico que capturó el `mousedown` real disparándose sobre `HTML`/el propio botón según el caso, y el desajuste entre atributo y clase.
- Después del fix: clic real → menú se abre y se mantiene abierto → clic real en "Excel (XLSX)" → genera `roadmap-IA_School_Bootcamp_-_P6.xlsx` con 20 filas → menú se cierra solo. Repetido en zoom "Día" con `exportRoadmap('png')`, sin errores.