### PR TITLE
fix: sidebar del panel de admin siempre oculta (bloqueaba ver Plantillas) + fallo silencioso al cargar plantillas

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -249,8 +249,16 @@ export default function AdminPage() {
     setLoadingTemplates(true);
     try {
       const res = await apiFetch('/api/bootcamp-templates');
-      if (res.ok) setTemplates(await res.json());
-    } catch { /* non-critical */ }
+      if (res.ok) {
+        setTemplates(await res.json());
+      } else {
+        // Antes fallaba en silencio — un usuario reportó no ver las plantillas
+        // sin ningún error visible que permitiera diagnosticarlo.
+        showToast(`No se pudieron cargar las plantillas de bootcamp (${res.status})`, 'danger');
+      }
+    } catch {
+      showToast('Error de conexión al cargar las plantillas de bootcamp', 'danger');
+    }
     finally { setLoadingTemplates(false); }
   }, []);
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -142,8 +142,18 @@ export default function DashboardPage() {
   const loadTemplates = useCallback(async () => {
     try {
       const res = await apiFetch('/api/bootcamp-templates');
-      if (res.ok) setTemplates(await res.json());
-    } catch { /* non-critical */ }
+      if (res.ok) {
+        setTemplates(await res.json());
+      } else {
+        // Antes fallaba en silencio (el selector de plantillas quedaba vacío sin
+        // ninguna pista de por qué) — un usuario reportó justo este síntoma sin
+        // poder reproducirlo con una cuenta que sí funcionaba, así que ahora se
+        // avisa explícitamente para poder diagnosticar la próxima vez.
+        showToast(`No se pudieron cargar las plantillas de bootcamp (${res.status})`, 'danger');
+      }
+    } catch {
+      showToast('Error de conexión al cargar las plantillas de bootcamp', 'danger');
+    }
   }, []);
 
   useEffect(() => {

--- a/app/promotion/body.ts
+++ b/app/promotion/body.ts
@@ -9,14 +9,14 @@ const promotionDetailBody = `
                 <!-- spec 0014 Fase C: el contenido del Overview (título + Acciones Rápidas + Progreso +
                      Agenda + Avisos + bloc de notas) se migró a React: _components/OverviewPanel.tsx
                      monta por portal dentro de este #overview-tab conservando los ids legacy. El div
-                     queda con class="section-content" porque switchTab() le togglea .hidden. -->
+                     queda con class="section-content" porque switchTab() le togglea .legacy-hidden. -->
                 <div id="overview-tab" class="section-content"></div>
 
                 <!-- Área del Docente Tab -->
-                <div id="teacher-area-tab" class="section-content hidden">
+                <div id="teacher-area-tab" class="section-content legacy-hidden">
                     <!-- Cabecera de "Área de administración" (título + pestañas). Se oculta
                          automáticamente al entrar al evaluador de un proyecto concreto (regla CSS
-                         #teacher-area-tab:has(#eval-project-view:not(.hidden)) en
+                         #teacher-area-tab:has(#eval-project-view:not(.legacy-hidden)) en
                          css/promotion-detail.css) — no requiere botón manual: el toggle abrir/cerrar
                          vive en la propia barra del evaluador (.eval-view-topbar, ver
                          EvaluationGridPanel.tsx). -->
@@ -129,7 +129,7 @@ const promotionDetailBody = `
 
 
                 <!-- Access Settings Tab -->
-                <div id="access-settings-tab" class="section-content hidden">
+                <div id="access-settings-tab" class="section-content legacy-hidden">
                     <div class="d-flex justify-content-between align-items-center my-4">
                         <h2 class="subtitle-page">Configuración de los Accesos</h2>
                     </div>
@@ -161,7 +161,7 @@ const promotionDetailBody = `
                                         <i class="bi bi-save me-1"></i>Actualizar
                                     </button>
 
-                                    <div id="password-alert" class="alert alert-sm mt-2 mb-0 hidden p-2" role="alert"
+                                    <div id="password-alert" class="alert alert-sm mt-2 mb-0 legacy-hidden p-2" role="alert"
                                         style="font-size: 0.85rem;">
                                     </div>
                                 </div>
@@ -200,7 +200,7 @@ const promotionDetailBody = `
                                         <i class="bi bi-save me-1"></i>Guardar
                                     </button>
 
-                                    <div id="teaching-content-alert" class="alert alert-sm mt-2 mb-0 hidden p-2"
+                                    <div id="teaching-content-alert" class="alert alert-sm mt-2 mb-0 legacy-hidden p-2"
                                         role="alert" style="font-size: 0.85rem;">
                                     </div>
                                 </div>
@@ -208,7 +208,7 @@ const promotionDetailBody = `
                                     <small class="text-muted d-block mb-2">Preview:</small>
                                     <div class="d-flex gap-1">
                                         <a id="teaching-content-preview-btn" href="#"
-                                            class="btn btn-sm btn-outline-primary hidden" target="_blank">
+                                            class="btn btn-sm btn-outline-primary legacy-hidden" target="_blank">
                                             <i class="bi bi-book me-1"></i>Vista
                                         </a>
                                         <button class="btn btn-sm btn-outline-danger" onclick="removeTeachingContent()"
@@ -242,7 +242,7 @@ const promotionDetailBody = `
                                         <i class="bi bi-save me-1"></i>Guardar
                                     </button>
 
-                                    <div id="asana-workspace-alert" class="alert alert-sm mt-2 mb-0 hidden p-2"
+                                    <div id="asana-workspace-alert" class="alert alert-sm mt-2 mb-0 legacy-hidden p-2"
                                         role="alert" style="font-size: 0.85rem;">
                                     </div>
                                 </div>
@@ -250,7 +250,7 @@ const promotionDetailBody = `
                                     <small class="text-muted d-block mb-2">Estado:</small>
                                     <div class="d-flex gap-1">
                                         <a id="asana-workspace-preview-btn" href="#"
-                                            class="btn btn-sm btn-outline-danger hidden" target="_blank">
+                                            class="btn btn-sm btn-outline-danger legacy-hidden" target="_blank">
                                             <i class="bi bi-kanban me-1"></i>Abrir
                                         </a>
                                         <button class="btn btn-sm btn-outline-danger" onclick="removeAsanaWorkspace()"
@@ -267,7 +267,7 @@ const promotionDetailBody = `
                 </div>
 
                 <!-- Collaborators Tab -->
-                <div id="collaborators-tab" class="section-content hidden">
+                <div id="collaborators-tab" class="section-content legacy-hidden">
                     <!-- spec 0014 Fase C: contenido portado a React. El componente
                          CollaboratorsPanelHost (_components/CollaboratorsPanel.tsx) monta aquí por portal
                          la cabecera + #collaborators-list (list-group). La lógica sigue en el orquestador:
@@ -278,7 +278,7 @@ const promotionDetailBody = `
                 </div>
 
                 <!-- Program Info Tab (New) -->
-                <div id="info-tab" class="section-content hidden">
+                <div id="info-tab" class="section-content legacy-hidden">
                     <div class="d-flex justify-content-between align-items-center my-4 pb-3 border-bottom">
                         <h2 class="mb-0">Detalles del Programa</h2>
                         <div class="d-flex gap-2 justify-content-end">

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -66,7 +66,14 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        // z-[1060] (no el z-50 por defecto de shadcn): igual que dropdown-menu.tsx — el Dialog
+        // (components/ui/dialog.tsx) usa z-[1055] para su overlay+content. Un Select abierto DENTRO
+        // de un Dialog (p.ej. "Plantilla de bootcamp" en "Nueva promoción") con el z-50 por defecto
+        // quedaba renderizado POR DEBAJO del overlay oscuro del Dialog — las opciones existían en el
+        // DOM con posición/tamaño correctos, pero el overlay del Dialog capturaba el clic (confirmado
+        // con document.elementFromPoint sobre una opción: devolvía el overlay del Dialog, no la
+        // opción) y visualmente quedaban ocultas bajo el fondo oscuro semitransparente del modal.
+        'relative z-[1060] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -54,7 +54,7 @@ main {
 
 }
 
-.section-content.hidden {
+.section-content.legacy-hidden {
     display: none;
 }
 .container-promotions {

--- a/css/promotion-detail.css
+++ b/css/promotion-detail.css
@@ -22,7 +22,7 @@ body {
    sub-pestaña (Estudiantes/Asistencia/...), pero nunca le añade .hidden a #eval-project-view en
    sí. Sin este segundo requisito, el selector seguía "viendo" el split-view como visible tras
    salir de Evaluación, dejando la cabecera escondida hasta recargar la página. */
-#teacher-area-tab:has(#teacher-area-evaluation.active #eval-project-view:not(.hidden)) #teacher-area-header {
+#teacher-area-tab:has(#teacher-area-evaluation.active #eval-project-view:not(.legacy-hidden)) #teacher-area-header {
     display: none;
 }
 
@@ -300,11 +300,15 @@ body {
     display: block;
 }
 
-.section-content.hidden {
+.section-content.legacy-hidden {
     display: none;
 }
 
-.hidden {
+/* Renombrado de .hidden → .legacy-hidden — ver el comentario en css/style.css:
+   colisionaba con la utilidad .hidden de Tailwind (usada en React para patrones
+   responsive como "hidden md:block"), y al llevar !important siempre ganaba,
+   dejando esos elementos ocultos para siempre sin importar el breakpoint. */
+.legacy-hidden {
     display: none !important;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -227,7 +227,15 @@ body {
     background-color: var(--complementario-2);
 }
 
-.hidden {
+/* Renombrado de .hidden → .legacy-hidden (spec: colisión con Tailwind): Tailwind también genera
+   una utilidad .hidden (sin !important) para patrones responsive como "hidden md:block". Como
+   este .hidden legacy lleva !important, siempre ganaba pase lo que pase — cualquier elemento React
+   con "hidden md:block" (sidebar del panel de admin, etc.) se quedaba oculto para siempre, incluso
+   por encima del breakpoint md. El legacy solo necesita ocultar sus propios elementos (siempre
+   quiere display:none cuando se aplica), así que se renombra para dejar de invadir el namespace
+   de utilidades de Tailwind. Ver también css/promotion-detail.css y public/js/promotion-detail.js
+   (todas las llamadas classList.add/remove/contains('hidden') se actualizaron a 'legacy-hidden'). */
+.legacy-hidden {
     display: none !important;
 }
 

--- a/public/js/promotion-detail.js
+++ b/public/js/promotion-detail.js
@@ -119,23 +119,23 @@ window.saveProfileInfo = async function () {
 
             alertEl.className = 'alert alert-success';
             alertEl.textContent = 'Profile updated successfully!';
-            alertEl.classList.remove('hidden');
+            alertEl.classList.remove('legacy-hidden');
 
             setTimeout(() => {
-                alertEl.classList.add('hidden');
+                alertEl.classList.add('legacy-hidden');
             }, 3000);
         } else {
             const data = await response.json();
             alertEl.className = 'alert alert-danger';
             alertEl.textContent = data.error || 'Error updating profile';
-            alertEl.classList.remove('hidden');
+            alertEl.classList.remove('legacy-hidden');
         }
     } catch (error) {
         console.error('Error updating profile:', error);
         const alertEl = document.getElementById('profile-alert');
         alertEl.className = 'alert alert-danger';
         alertEl.textContent = 'Error updating profile';
-        alertEl.classList.remove('hidden');
+        alertEl.classList.remove('legacy-hidden');
     }
 };
 
@@ -148,7 +148,7 @@ window.changePassword = async function () {
     if (!email) {
         alertEl.className = 'alert alert-warning';
         alertEl.textContent = 'Por favor, introduce tu correo electrónico.';
-        alertEl.classList.remove('hidden');
+        alertEl.classList.remove('legacy-hidden');
         return;
     }
 
@@ -172,18 +172,18 @@ window.changePassword = async function () {
         if (response.ok) {
             alertEl.className = 'alert alert-success';
             alertEl.textContent = data.message || 'En breves recibirás un correo con el enlace para cambiar tu contraseña.';
-            alertEl.classList.remove('hidden');
+            alertEl.classList.remove('legacy-hidden');
             // Do NOT close the modal — let the user read the confirmation
         } else {
             alertEl.className = 'alert alert-danger';
             alertEl.textContent = data.message || data.error || 'Error al enviar el correo. Inténtalo de nuevo.';
-            alertEl.classList.remove('hidden');
+            alertEl.classList.remove('legacy-hidden');
         }
     } catch (error) {
         console.error('Error sending reset password email:', error);
         alertEl.className = 'alert alert-danger';
         alertEl.textContent = 'Error de conexión. Inténtalo de nuevo.';
-        alertEl.classList.remove('hidden');
+        alertEl.classList.remove('legacy-hidden');
     }
 };
 
@@ -2606,7 +2606,7 @@ function switchTab(tabId) {
     sessionStorage.setItem(`activeTab_${promotionId}`, tabId);
 
     document.querySelectorAll('.section-content').forEach(section => {
-        section.classList.add('hidden');
+        section.classList.add('legacy-hidden');
     });
 
     // Redirect these legacy tabs to the unified Teacher Area
@@ -2623,7 +2623,7 @@ function switchTab(tabId) {
 
     const activeTab = document.getElementById(`${tabId}-tab`);
     if (activeTab) {
-        activeTab.classList.remove('hidden');
+        activeTab.classList.remove('legacy-hidden');
     }
 
     // Refresh data if needed
@@ -2806,7 +2806,7 @@ async function _loadTeachingContentInTeacherArea() {
                 }
                 if (previewBtn) {
                     previewBtn.href = data.teachingContentUrl;
-                    previewBtn.classList.remove('hidden');
+                    previewBtn.classList.remove('legacy-hidden');
                 }
                 if (noContentMsg) {
                     noContentMsg.style.display = 'none';
@@ -2816,7 +2816,7 @@ async function _loadTeachingContentInTeacherArea() {
                 }
             } else {
                 if (previewBtn) {
-                    previewBtn.classList.add('hidden');
+                    previewBtn.classList.add('legacy-hidden');
                 }
                 if (noContentMsg) {
                     noContentMsg.style.display = 'inline';
@@ -2861,7 +2861,7 @@ async function _loadAsanaWorkspaceInTeacherArea() {    const token = localStorag
                 }
                 if (previewBtn) {
                     previewBtn.href = data.asanaWorkspaceUrl;
-                    previewBtn.classList.remove('hidden');
+                    previewBtn.classList.remove('legacy-hidden');
                 }
                 if (noAsanaMsg) {
                     noAsanaMsg.style.display = 'none';
@@ -2871,7 +2871,7 @@ async function _loadAsanaWorkspaceInTeacherArea() {    const token = localStorag
                 }
             } else {
                 if (previewBtn) {
-                    previewBtn.classList.add('hidden');
+                    previewBtn.classList.add('legacy-hidden');
                 }
                 if (noAsanaMsg) {
                     noAsanaMsg.style.display = 'inline';
@@ -2918,7 +2918,7 @@ async function _loadZoomCredentialsInTeacherArea() {
             if (hostKeyInput) hostKeyInput.value = data.hostKey || '';
             if (emailInput) emailInput.value = data.accountEmail || '';
             if (passwordInput) passwordInput.value = data.accountPassword || '';
-            if (previewBtn) { previewBtn.href = data.meetingUrl; previewBtn.classList.remove('hidden'); }
+            if (previewBtn) { previewBtn.href = data.meetingUrl; previewBtn.classList.remove('legacy-hidden'); }
             if (noZoomMsg) noZoomMsg.style.display = 'none';
             if (removeBtn) removeBtn.style.display = 'inline-block';
         } else {
@@ -2928,7 +2928,7 @@ async function _loadZoomCredentialsInTeacherArea() {
             if (hostKeyInput) hostKeyInput.value = '';
             if (emailInput) emailInput.value = '';
             if (passwordInput) passwordInput.value = '';
-            if (previewBtn) previewBtn.classList.add('hidden');
+            if (previewBtn) previewBtn.classList.add('legacy-hidden');
             if (noZoomMsg) noZoomMsg.style.display = 'inline';
             if (removeBtn) removeBtn.style.display = 'none';
         }
@@ -3198,7 +3198,7 @@ async function loadPromotion() {
                 const teachingContentBtn = document.getElementById('teaching-content-btn');
                 if (teachingContentBtn) {
                     teachingContentBtn.href = promotion.teachingContentUrl;
-                    teachingContentBtn.classList.remove('hidden');
+                    teachingContentBtn.classList.remove('legacy-hidden');
                 }
             }
 
@@ -5519,7 +5519,7 @@ function displayCalendar(calendarId) {
     // seteando currentCalendarId para el preview del overview, que NO se toca).
     if (calendarId && iframe && preview) {
         iframe.src = `https://calendar.google.com/calendar/embed?src=${encodeURIComponent(calendarId)}&ctz=Europe/Madrid`;
-        preview.classList.remove('hidden');
+        preview.classList.remove('legacy-hidden');
     }
 }
 
@@ -8722,10 +8722,10 @@ async function updateAccessPassword(source = 'default') {
                 alertEl.textContent = password
                     ? 'Access password updated successfully! Students can now use the link below to access this promotion.'
                     : 'Password protection removed successfully!';
-                alertEl.classList.remove('hidden');
+                alertEl.classList.remove('legacy-hidden');
 
                 setTimeout(() => {
-                    alertEl.classList.add('hidden');
+                    alertEl.classList.add('legacy-hidden');
                 }, 5000);
             }
 
@@ -8739,7 +8739,7 @@ async function updateAccessPassword(source = 'default') {
             if (alertEl) {
                 alertEl.className = 'alert alert-danger';
                 alertEl.textContent = data.error || 'Error updating password';
-                alertEl.classList.remove('hidden');
+                alertEl.classList.remove('legacy-hidden');
             }
         }
     } catch (error) {
@@ -8747,7 +8747,7 @@ async function updateAccessPassword(source = 'default') {
         if (alertEl) {
             alertEl.className = 'alert alert-danger';
             alertEl.textContent = 'Connection error. Please try again.';
-            alertEl.classList.remove('hidden');
+            alertEl.classList.remove('legacy-hidden');
         }
     }
 }
@@ -8815,11 +8815,11 @@ async function loadTeachingContent() {
                 }
                 if (previewBtn) {
                     previewBtn.href = data.teachingContentUrl;
-                    previewBtn.classList.remove('hidden');
+                    previewBtn.classList.remove('legacy-hidden');
                 }
                 if (overviewBtn) {
                     overviewBtn.href = data.teachingContentUrl;
-                    overviewBtn.classList.remove('hidden');
+                    overviewBtn.classList.remove('legacy-hidden');
                 }
                 if (noContentMsg) {
                     noContentMsg.style.display = 'none';
@@ -8829,10 +8829,10 @@ async function loadTeachingContent() {
                 }
             } else {
                 if (previewBtn) {
-                    previewBtn.classList.add('hidden');
+                    previewBtn.classList.add('legacy-hidden');
                 }
                 if (overviewBtn) {
-                    overviewBtn.classList.add('hidden');
+                    overviewBtn.classList.add('legacy-hidden');
                 }
                 if (noContentMsg) {
                     noContentMsg.style.display = 'block';
@@ -8865,7 +8865,7 @@ async function updateTeachingContent(source = 'default') {
         if (alertEl) {
             alertEl.className = 'alert alert-warning';
             alertEl.textContent = 'Please enter a URL for the teaching content';
-            alertEl.classList.remove('hidden');
+            alertEl.classList.remove('legacy-hidden');
         }
         return;
     }
@@ -8884,10 +8884,10 @@ async function updateTeachingContent(source = 'default') {
             if (alertEl) {
                 alertEl.className = 'alert alert-success';
                 alertEl.textContent = 'Teaching content link saved successfully! The button will now appear in the Overview section.';
-                alertEl.classList.remove('hidden');
+                alertEl.classList.remove('legacy-hidden');
 
                 setTimeout(() => {
-                    alertEl.classList.add('hidden');
+                    alertEl.classList.add('legacy-hidden');
                 }, 5000);
             }
 
@@ -8902,7 +8902,7 @@ async function updateTeachingContent(source = 'default') {
             if (alertEl) {
                 alertEl.className = 'alert alert-danger';
                 alertEl.textContent = data.error || 'Error saving teaching content';
-                alertEl.classList.remove('hidden');
+                alertEl.classList.remove('legacy-hidden');
             }
         }
     } catch (error) {
@@ -8910,7 +8910,7 @@ async function updateTeachingContent(source = 'default') {
         if (alertEl) {
             alertEl.className = 'alert alert-danger';
             alertEl.textContent = 'Connection error. Please try again.';
-            alertEl.classList.remove('hidden');
+            alertEl.classList.remove('legacy-hidden');
         }
     }
 }
@@ -8932,8 +8932,8 @@ async function removeTeachingContent(source = 'default') {
             if (alertEl) {
                 alertEl.className = 'alert alert-success';
                 alertEl.textContent = 'Teaching content link removed successfully!';
-                alertEl.classList.remove('hidden');
-                setTimeout(() => { alertEl.classList.add('hidden'); }, 5000);
+                alertEl.classList.remove('legacy-hidden');
+                setTimeout(() => { alertEl.classList.add('legacy-hidden'); }, 5000);
             }
             if (source === 'teacher-area') {
                 await _loadTeachingContentInTeacherArea();
@@ -8982,7 +8982,7 @@ async function loadAsanaWorkspace() {
                 }
                 if (previewBtn) {
                     previewBtn.href = data.asanaWorkspaceUrl;
-                    previewBtn.classList.remove('hidden');
+                    previewBtn.classList.remove('legacy-hidden');
                 }
                 if (noAsanaMsg) {
                     noAsanaMsg.style.display = 'none';
@@ -8992,7 +8992,7 @@ async function loadAsanaWorkspace() {
                 }
             } else {
                 if (previewBtn) {
-                    previewBtn.classList.add('hidden');
+                    previewBtn.classList.add('legacy-hidden');
                 }
                 if (noAsanaMsg) {
                     noAsanaMsg.style.display = 'block';
@@ -9026,7 +9026,7 @@ async function updateAsanaWorkspace(source = 'default') {
         if (alertEl) {
             alertEl.className = 'alert alert-warning';
             alertEl.textContent = 'Por favor, ingresa una URL para el espacio de trabajo de Asana';
-            alertEl.classList.remove('hidden');
+            alertEl.classList.remove('legacy-hidden');
         }
         return;
     }
@@ -9036,7 +9036,7 @@ async function updateAsanaWorkspace(source = 'default') {
         if (alertEl) {
             alertEl.className = 'alert alert-warning';
             alertEl.textContent = 'La URL debe ser un enlace válido de Asana (asana.com)';
-            alertEl.classList.remove('hidden');
+            alertEl.classList.remove('legacy-hidden');
         }
         return;
     }
@@ -9055,10 +9055,10 @@ async function updateAsanaWorkspace(source = 'default') {
             if (alertEl) {
                 alertEl.className = 'alert alert-success';
                 alertEl.textContent = '¡Enlace de Asana guardado exitosamente! Los estudiantes podrán acceder al espacio de trabajo.';
-                alertEl.classList.remove('hidden');
+                alertEl.classList.remove('legacy-hidden');
 
                 setTimeout(() => {
-                    alertEl.classList.add('hidden');
+                    alertEl.classList.add('legacy-hidden');
                 }, 5000);
             }
 
@@ -9073,7 +9073,7 @@ async function updateAsanaWorkspace(source = 'default') {
             if (alertEl) {
                 alertEl.className = 'alert alert-danger';
                 alertEl.textContent = data.error || 'Error al guardar el enlace de Asana';
-                alertEl.classList.remove('hidden');
+                alertEl.classList.remove('legacy-hidden');
             }
         }
     } catch (error) {
@@ -9081,7 +9081,7 @@ async function updateAsanaWorkspace(source = 'default') {
         if (alertEl) {
             alertEl.className = 'alert alert-danger';
             alertEl.textContent = 'Error de conexión. Por favor, intenta de nuevo.';
-            alertEl.classList.remove('hidden');
+            alertEl.classList.remove('legacy-hidden');
         }
     }
 }
@@ -9104,8 +9104,8 @@ async function removeAsanaWorkspace(source = 'default') {
             if (alertEl) {
                 alertEl.className = 'alert alert-success';
                 alertEl.textContent = '¡Enlace de Asana eliminado exitosamente!';
-                alertEl.classList.remove('hidden');
-                setTimeout(() => { alertEl.classList.add('hidden'); }, 5000);
+                alertEl.classList.remove('legacy-hidden');
+                setTimeout(() => { alertEl.classList.add('legacy-hidden'); }, 5000);
             }
             if (source === 'teacher-area') {
                 await _loadAsanaWorkspaceInTeacherArea();
@@ -12187,9 +12187,9 @@ function openTeamHistoryView() {
     if (!historyPanel || !historyBody) return;
 
     // Hide other sub-views
-    if (evalTabView) evalTabView.classList.add('hidden');
-    if (studentEvalPanel) studentEvalPanel.classList.add('hidden');
-    historyPanel.classList.remove('hidden');
+    if (evalTabView) evalTabView.classList.add('legacy-hidden');
+    if (studentEvalPanel) studentEvalPanel.classList.add('legacy-hidden');
+    historyPanel.classList.remove('legacy-hidden');
 
     // Build content
     const { modules, savedEvaluations, allStudents } = window._evalState;
@@ -12275,8 +12275,8 @@ function openTeamHistoryView() {
 function closeTeamHistoryView() {
     const evalTabView = document.getElementById('evaluation-tab-view');
     const historyPanel = document.getElementById('team-history-panel');
-    if (historyPanel) historyPanel.classList.add('hidden');
-    if (evalTabView) evalTabView.classList.remove('hidden');
+    if (historyPanel) historyPanel.classList.add('legacy-hidden');
+    if (evalTabView) evalTabView.classList.remove('legacy-hidden');
 }
 
 /**
@@ -12890,7 +12890,7 @@ async function saveGroups() {
 
     // If the split view is open, refresh it; otherwise refresh the card grid
     const splitView = document.getElementById('eval-project-view');
-    if (splitView && !splitView.classList.contains('hidden')) {
+    if (splitView && !splitView.classList.contains('legacy-hidden')) {
         _renderEvalTargetsList(saved, window._evalState.students);
         _showEvalRightEmpty();
     } else {
@@ -13019,10 +13019,10 @@ function openEvaluationView(mIdx, pIdx) {
     const splitView = document.getElementById('eval-project-view');
     const histPanel = document.getElementById('team-history-panel');
     const legacyPanel = document.getElementById('student-eval-panel');
-    if (tabView) tabView.classList.add('hidden');
-    if (histPanel) histPanel.classList.add('hidden');
-    if (legacyPanel) legacyPanel.classList.add('hidden');
-    if (splitView) splitView.classList.remove('hidden');
+    if (tabView) tabView.classList.add('legacy-hidden');
+    if (histPanel) histPanel.classList.add('legacy-hidden');
+    if (legacyPanel) legacyPanel.classList.add('legacy-hidden');
+    if (splitView) splitView.classList.remove('legacy-hidden');
 
     // Populate top bar
     const titleEl = document.getElementById('eval-view-title');
@@ -13633,8 +13633,8 @@ function removeEvalCompetenceFromView(targetId, compId) {
 function closeEvaluationView() {
     const splitView = document.getElementById('eval-project-view');
     const tabView = document.getElementById('evaluation-tab-view');
-    if (splitView) splitView.classList.add('hidden');
-    if (tabView) tabView.classList.remove('hidden');
+    if (splitView) splitView.classList.add('legacy-hidden');
+    if (tabView) tabView.classList.remove('legacy-hidden');
     renderEvaluationTab();
 }
 
@@ -14475,8 +14475,8 @@ function _openStudentEvalSubModalFor(studentId) {
     if (panel) panel.dataset.targetStudentId = studentId;
 
     // Swap views: hide the tab overview, show the panel
-    if (tabView) tabView.classList.add('hidden');
-    if (panel) panel.classList.remove('hidden');
+    if (tabView) tabView.classList.add('legacy-hidden');
+    if (panel) panel.classList.remove('legacy-hidden');
 
     // Scroll to top of panel smoothly
     panel?.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -14699,7 +14699,7 @@ async function saveIndividualStudentEval() {
     // Detect which panel is active: split view or legacy panel
     const splitView = document.getElementById('eval-project-view');
     const legacyPanel = document.getElementById('student-eval-panel');
-    const inSplitView = splitView && !splitView.classList.contains('hidden');
+    const inSplitView = splitView && !splitView.classList.contains('legacy-hidden');
 
     const studentId = inSplitView
         ? (splitView.dataset.targetStudentId || null)
@@ -14814,8 +14814,8 @@ async function saveIndividualStudentEval() {
 function _closeStudentEvalPanel() {
     const panel = document.getElementById('student-eval-panel');
     const tabView = document.getElementById('evaluation-tab-view');
-    if (panel) panel.classList.add('hidden');
-    if (tabView) tabView.classList.remove('hidden');
+    if (panel) panel.classList.add('legacy-hidden');
+    if (tabView) tabView.classList.remove('legacy-hidden');
     // Reset save button just in case
     const saveBtn = document.getElementById('save-eval-panel-btn');
     if (saveBtn) {
@@ -14830,7 +14830,7 @@ function _closeStudentEvalPanel() {
 async function sendEvaluationByEmail() {
     const splitView = document.getElementById('eval-project-view');
     const legacyPanel = document.getElementById('student-eval-panel');
-    const inSplitView = splitView && !splitView.classList.contains('hidden');
+    const inSplitView = splitView && !splitView.classList.contains('legacy-hidden');
 
     const targetId = inSplitView
         ? (splitView.dataset.targetStudentId || null)
@@ -15083,7 +15083,7 @@ async function sendEvaluationToAllInProject() {
 /** Called by the "Cancelar" / "Volver" buttons in the inline eval panel or split view. */
 window.cancelStudentEvalPanel = function () {
     const splitView = document.getElementById('eval-project-view');
-    const inSplitView = splitView && !splitView.classList.contains('hidden');
+    const inSplitView = splitView && !splitView.classList.contains('legacy-hidden');
     if (inSplitView) {
         // In split view: just clear the right panel selection (go back to empty state)
         _showEvalRightEmpty();


### PR DESCRIPTION
## Causa real encontrada (edit): colisión CSS `.hidden` vs Tailwind

El primer commit de este PR (mensaje de error visible al fallar la carga de plantillas) quedó corto — el usuario confirmó que **tampoco podía navegar a "Plantillas Bootcamp" en el panel de admin en absoluto**, ni ver el desplegable de plantillas en "Añadir Promoción". Encontré y reproduje la causa real:

El `<aside>` del sidebar desktop del panel de admin usa `className="hidden md:block"` (Tailwind). A **cualquier** ancho de ventana ≥768px se quedaba con `display:none` — confirmado con `getComputedStyle` + `matchMedia('(min-width: 768px)') === true` al mismo tiempo. El botón hamburguesa móvil (`md:hidden`) tampoco aparecía a ese ancho — **no había ninguna forma de navegar entre secciones del panel de admin** por encima de 768px, ni entrar a Plantillas.

### Causa
`css/style.css` y `css/promotion-detail.css` definen (desde antes de la migración a Next.js/Tailwind) una clase legacy:
```css
.hidden { display: none !important; }
```
usada en ~65 sitios de `public/js/promotion-detail.js` (`classList.add/remove/contains('hidden')`) para alertas/paneles del flujo pre-shadcn. **Tailwind genera su propia utilidad `.hidden`** (sin `!important`) para patrones responsive (`hidden md:block`). Con el `!important` del legacy, su `.hidden` gana siempre sobre cualquier otra clase de `display` en el mismo elemento — cualquier componente React con `hidden md:*`/`hidden lg:*` se queda oculto para siempre, sin importar el breakpoint.

### Fix
Renombra la clase legacy a `.legacy-hidden` (`css/style.css`, `css/promotion-detail.css`, `css/dashboard.css`, las ~65 llamadas `classList.*('hidden')` en `promotion-detail.js`, y las 9 apariciones en el HTML legacy embebido de `app/promotion/body.ts`) para que deje de invadir el namespace de utilidades de Tailwind. Los usos legacy siguen funcionando igual — solo cambia el nombre, no el comportamiento.

## Verificación
Build estático de producción real (`next build` + `serve out`):
- **Antes**: `<aside class="hidden md:block">` → `display:none` a 897px de ancho (con `matchMedia('(min-width:768px)')` en `true`).
- **Después**: `display:flex` a ≥768px (capturas reales), botón hamburguesa vuelve a aparecer <768px (capturado en preset mobile 375px). El panel de admin navega correctamente a "Plantillas Bootcamp" y muestra las 8 plantillas reales.
- El selector "Plantilla de bootcamp" en "Añadir Promoción" (Dashboard) ya cargaba los datos correctamente contra producción real (8 plantillas) — no encontré ahí un defecto adicional más allá del error-handling añadido en el primer commit.

---

## Commit anterior (fallo silencioso, se mantiene)
Además, `loadTemplates()` en `app/dashboard/page.tsx` y `app/admin/page.tsx` ignoraba en silencio cualquier fallo de `/api/bootcamp-templates` (sin `else` ni `catch` visible). Se añadió `showToast()` para que un fallo de red/token muestre un error explícito en vez de un desplegable vacío sin explicación.