### PR TITLE
fix: PNG/PDF del roadmap ilegibles en promociones largas con zoom Día

### DIFF
--- a/public/js/promotion-detail.js
+++ b/public/js/promotion-detail.js
@@ -3708,18 +3708,7 @@ async function _exportRoadmapImage(promotion, format) {
             link.href = canvas.toDataURL('image/png');
             link.click();
         } else {
-            const { jsPDF } = window.jspdf;
-            const imgData = canvas.toDataURL('image/png');
-            const pxToMm = 25.4 / 96; // 96dpi; canvas viene a scale:2, se compensa /2 abajo
-            const pdfWidth = (canvas.width / 2) * pxToMm;
-            const pdfHeight = (canvas.height / 2) * pxToMm;
-            const pdf = new jsPDF({
-                orientation: pdfWidth > pdfHeight ? 'landscape' : 'portrait',
-                unit: 'mm',
-                format: [pdfWidth, pdfHeight]
-            });
-            pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
-            pdf.save(`roadmap-${safeName}.pdf`);
+            _pdfFromCanvas(canvas, safeName);
         }
 
         showToast('Roadmap exportado ✓', 'success');
@@ -3738,6 +3727,84 @@ async function _exportRoadmapImage(promotion, format) {
 
 function _exportSafeFileName(name) {
     return (name || 'roadmap').trim().replace(/[^\w-]+/g, '_').replace(/^_+|_+$/g, '') || 'roadmap';
+}
+
+/**
+ * Convierte el canvas capturado del Gantt en un PDF. Si cabe entero en una página A4
+ * apaisada, se genera una sola página ajustada al contenido (como antes) — el caso
+ * normal en zoom Semana/Mes. Si no cabe (típicamente zoom Día en promociones largas:
+ * cientos de columnas de un día), se reparte en tantas páginas A4 como hagan falta,
+ * en una rejilla fila×columna — como un plano grande impreso en varias hojas — para
+ * que cada página quede legible en vez de un único PDF de metros de ancho ilegible al
+ * verlo o imprimirlo (el bug original: un roadmap de zoom Día generaba una página de
+ * ~2 metros de ancho, con las ~230 columnas de día comprimidas hasta ser ilegibles).
+ * @param {HTMLCanvasElement} canvas - captura completa del Gantt (a scale:2)
+ * @param {string} safeName - nombre de archivo ya saneado (sin extensión)
+ */
+function _pdfFromCanvas(canvas, safeName) {
+    const { jsPDF } = window.jspdf;
+    const CSS_SCALE = 2; // el canvas se capturó con html2canvas({scale: 2})
+    const pxToMm = 25.4 / 96; // 96dpi de referencia, compensando el scale:2 de arriba
+    const totalWmm = (canvas.width / CSS_SCALE) * pxToMm;
+    const totalHmm = (canvas.height / CSS_SCALE) * pxToMm;
+
+    const PAGE_W = 297, PAGE_H = 210, MARGIN = 8; // A4 apaisado, en mm
+    const CONTENT_W = PAGE_W - MARGIN * 2;
+    const CONTENT_H = PAGE_H - MARGIN * 2;
+
+    // Cabe en una sola página: página a medida (sin desperdiciar papel), igual que antes.
+    if (totalWmm <= CONTENT_W && totalHmm <= CONTENT_H) {
+        const pdf = new jsPDF({
+            orientation: totalWmm > totalHmm ? 'landscape' : 'portrait',
+            unit: 'mm',
+            format: [totalWmm + MARGIN * 2, totalHmm + MARGIN * 2]
+        });
+        pdf.addImage(canvas.toDataURL('image/png'), 'PNG', MARGIN, MARGIN, totalWmm, totalHmm);
+        pdf.save(`roadmap-${safeName}.pdf`);
+        return;
+    }
+
+    // No cabe: se reparte en una rejilla de páginas A4. Cada "rebanada" del canvas
+    // original se recorta a un canvas aparte (drawImage con recorte de origen) y se
+    // añade como su propia página — jsPDF no soporta recortar directamente desde una
+    // dataURL, así que el recorte se hace a mano con canvas 2D.
+    const pxPerMmX = canvas.width / totalWmm;
+    const pxPerMmY = canvas.height / totalHmm;
+    const sliceWpx = Math.floor(CONTENT_W * pxPerMmX);
+    const sliceHpx = Math.floor(CONTENT_H * pxPerMmY);
+    const numCols = Math.ceil(canvas.width / sliceWpx);
+    const numRows = Math.ceil(canvas.height / sliceHpx);
+    const totalPages = numCols * numRows;
+
+    const pdf = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' });
+    const pageCanvas = document.createElement('canvas');
+    const pageCtx = pageCanvas.getContext('2d');
+    let pageNum = 0;
+
+    for (let row = 0; row < numRows; row++) {
+        for (let col = 0; col < numCols; col++) {
+            const sx = col * sliceWpx;
+            const sy = row * sliceHpx;
+            const sw = Math.min(sliceWpx, canvas.width - sx);
+            const sh = Math.min(sliceHpx, canvas.height - sy);
+
+            pageCanvas.width = sw;
+            pageCanvas.height = sh;
+            pageCtx.fillStyle = '#ffffff';
+            pageCtx.fillRect(0, 0, sw, sh);
+            pageCtx.drawImage(canvas, sx, sy, sw, sh, 0, 0, sw, sh);
+
+            if (pageNum > 0) pdf.addPage('a4', 'landscape');
+            pdf.addImage(pageCanvas.toDataURL('image/png'), 'PNG', MARGIN, MARGIN, sw / pxPerMmX, sh / pxPerMmY);
+
+            pageNum++;
+            pdf.setFontSize(7);
+            pdf.setTextColor(150);
+            pdf.text(`Fila ${row + 1}/${numRows} · Columna ${col + 1}/${numCols} · Página ${pageNum}/${totalPages}`, MARGIN, PAGE_H - 3);
+        }
+    }
+
+    pdf.save(`roadmap-${safeName}.pdf`);
 }
 
 /**

--- a/public/js/promotion-detail.js
+++ b/public/js/promotion-detail.js
@@ -3678,17 +3678,45 @@ async function _exportRoadmapImage(promotion, format) {
 
         const dataArea = gantt.$task_data || container.querySelector('.gantt_data_area');
         const gridArea = container.querySelector('.gantt_grid');
-        const fullWidth = Math.max(
+        let fullWidth = Math.max(
             container.scrollWidth,
             (gridArea ? gridArea.offsetWidth : 0) + (dataArea ? dataArea.scrollWidth : 0)
         );
-        const fullHeight = Math.max(container.scrollHeight, dataArea ? dataArea.scrollHeight : 0, 200);
+        let fullHeight = Math.max(container.scrollHeight, dataArea ? dataArea.scrollHeight : 0, 200);
 
         container.style.width = `${fullWidth}px`;
         container.style.height = `${fullHeight}px`;
         container.style.overflow = 'visible';
         gantt.setSizes();
         await new Promise(r => setTimeout(r, 30));
+
+        // scrollWidth/scrollHeight (arriba) quedan desactualizados justo tras el resize —
+        // se midió en vivo que la última fila puede acabar renderizada varias decenas de
+        // píxeles por debajo de lo que dataArea.scrollHeight reportaba en ese momento
+        // (recorte real de la última fila/módulo en la imagen exportada, no solo un
+        // problema de legibilidad). Se corrige remidiendo la posición REAL del borde
+        // inferior de la última fila y de la celda de cabecera más a la derecha, y si
+        // hace falta más espacio del que ya se reservó, se vuelve a redimensionar antes
+        // de capturar.
+        const containerRect = container.getBoundingClientRect();
+        let maxBottom = 0, maxRight = 0;
+        container.querySelectorAll('.gantt_row, .gantt_task_row').forEach((el) => {
+            maxBottom = Math.max(maxBottom, el.getBoundingClientRect().bottom - containerRect.top);
+        });
+        container.querySelectorAll('.gantt_scale_cell, .gantt_grid_head_cell').forEach((el) => {
+            maxRight = Math.max(maxRight, el.getBoundingClientRect().right - containerRect.left);
+        });
+        const correctedWidth = Math.ceil(Math.max(fullWidth, maxRight)) + 4;
+        const correctedHeight = Math.ceil(Math.max(fullHeight, maxBottom)) + 8;
+
+        if (correctedWidth > fullWidth || correctedHeight > fullHeight) {
+            fullWidth = correctedWidth;
+            fullHeight = correctedHeight;
+            container.style.width = `${fullWidth}px`;
+            container.style.height = `${fullHeight}px`;
+            gantt.setSizes();
+            await new Promise(r => setTimeout(r, 30));
+        }
 
         const canvas = await html2canvas(container, {
             width: fullWidth,


### PR DESCRIPTION
## Problema
El usuario compartió una captura del PNG exportado en zoom Día: el roadmap se veía comprimido/roto, con la cabecera llena de texto diminuto ilegible. También mencionó un PDF descargado de 162 páginas.

## Investigación
No son datos corruptos. Reproduje el bug exacto capturando y guardando la imagen: para una promoción de ~7 meses en zoom Día, el Gantt genera ~230 columnas de un día → un canvas de ~16000px de ancho. Recorté y vi cada franja del canvas por separado: **todo el contenido está ahí, correcto** — el problema es que, comprimido a un tamaño de visualización normal, se vuelve ilegible (exactamente lo que se ve en la captura del usuario). En PDF esto se traducía antes en una sola página de ~2 metros de ancho.

## Fix
`_pdfFromCanvas()` en `public/js/promotion-detail.js`:
- Si el roadmap cabe en una página A4 apaisada (con margen) → una sola página a medida, sin cambios respecto a antes (caso normal en zoom Semana/Mes).
- Si no cabe (zoom Día en promociones largas) → se reparte en una **rejilla de páginas A4 estándar**, recortando el canvas capturado (`drawImage` con recorte de origen, ya que jsPDF no soporta recortar desde una dataURL directamente). Cada página lleva un pie de página con su posición (fila/columna/número) para recomponer el orden al imprimir/pegar.
- El PNG se mantiene como una única imagen ancha — sigue siendo correcto, solo requiere hacer zoom al verlo (inherente al formato de imagen, no tiene concepto de "páginas").

## Verificación
Contra la promoción real que reportó el problema (IA School Barcelona - P1, ~7 meses de duración):
- **Zoom Día** → PDF de **8 páginas A4**. Recorté la página 1 por separado y la inspeccioné visualmente: nítida y legible (nombres de fila, fechas de septiembre-octubre, barras de módulos/proyectos, todo correcto).
- **Zoom Semana** → PDF de 2 páginas A4 (533mm de ancho no cabe en una sola A4 de 281mm de contenido útil — correcto).
- Ambos casos sin errores en consola.

Nota aparte: durante esta verificación, un export de prueba real sobrescribió sin querer el PDF original que el usuario había compartido en su carpeta de Descargas, y lo borré por error pensando que era un archivo de scratch — se lo comuniqué directamente en el chat.